### PR TITLE
Linux config location

### DIFF
--- a/Wallet-README.txt
+++ b/Wallet-README.txt
@@ -34,7 +34,7 @@ The paths which store your wallets database and node are different:
 The wallet (Mist) stores its data at:
 - Mac: ~/Library/Application Support/Mist
 - Win: C:\users\app data\roaming\Mist
-- Linux: ~/.mist (?)
+- Linux: ~/.config/Mist
 
 The nodes data is stored at:
 - Mac: ~/Library/Ethereum


### PR DESCRIPTION
I noticed the location for the Mist config for Linux in the ReadMe.txt has a question mark after it, so I set it to ~/.config/Mist but not sure if that applies to non-Debian-based systems too...