### PR TITLE
Update ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,5 +10,7 @@ Add the following to issue, when possible:
 
 - Screenshots
 - Check the console, of Mist (CTRL/CMD + ALT + i) and take a screenshot.
-- Log files (osx: ~/Library/Application Support/Mist/node.log, windows: %APPDATA%/Roaming/Mist/node.log, linux: ~/.config/Mist/node.log)
-
+- Log files (as ZIP archive)
+-   osx: ~/Library/Application Support/Mist/node.log (Open Home folder > Show View Options > Show Library Folder)
+-   windows: %APPDATA%/Roaming/Mist/node.log
+-   linux: ~/.config/Mist/node.log


### PR DESCRIPTION
log files can't be uploaded to github, users should zip
osx user library isn't displayed by default on yosemite, added quick instructions