### PR TITLE
log4js integration

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const ipc = electron.ipcMain;
 const dialog = require('dialog');
 const packageJson = require('./package.json');
 const i18n = require('./modules/i18n.js');
+const logger = require('./modules/utils/logger');
 
 // CLI options
 const argv = require('yargs')
@@ -20,6 +21,8 @@ const argv = require('yargs')
     .describe('gethpath', 'Path to geth executable to use instead of default')
     .describe('ethpath', 'Path to eth executable to use instead of default')
     .describe('ignore-gpu-blacklist', 'Ignores GPU blacklist (needed for some Linux installations)')
+    .describe('logfile', 'Logs will be written to this file')
+    .describe('loglevel', 'Minimum logging threshold: trace, debug, info (default), warn, error')
     .alias('m', 'mode')
     .help('h')
     .alias('h', 'help')
@@ -33,6 +36,10 @@ if (argv.version) {
 if (argv.ignoreGpuBlacklist) {
     app.commandLine.appendSwitch('ignore-gpu-blacklist', 'true');
 }
+
+// logging setup
+logger.setup(argv);
+const log = logger.create('main');
 
 // GLOBAL Variables
 global.path = {
@@ -64,7 +71,6 @@ const ethereumNodes = require('./modules/ethereumNodes.js');
 const getIpcPath = require('./modules/ipc/getIpcPath.js');
 var ipcPath = getIpcPath();
 
-
 global.mainWindow = null;
 global.windows = {};
 global.webviews = [];
@@ -91,6 +97,8 @@ global.interfacePopupsUrl;
 
 // WALLET
 if(global.mode === 'wallet') {
+    log.info('Starting in Wallet mode');
+
     global.interfaceAppUrl = (global.production)
         ? 'file://' + __dirname + '/interface/wallet/index.html'
         : 'http://localhost:3050';
@@ -100,6 +108,8 @@ if(global.mode === 'wallet') {
 
 // MIST
 } else {
+    log.info('Starting in Mist mode');
+
     global.interfaceAppUrl = global.interfacePopupsUrl = (global.production)
         ? 'file://' + __dirname + '/interface/index.html'
         : 'http://localhost:3000';
@@ -126,12 +136,15 @@ if(global.mode === 'wallet') {
 
 // prevent crashed and close gracefully
 process.on('uncaughtException', function(error){
-    console.log('UNCAUGHT EXCEPTION', error.stack || error);
+    log.error('UNCAUGHT EXCEPTION', error);
+
     // var stack = new Error().stack;
     // console.log(stack);
 
     app.quit();
 });
+
+
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {
@@ -141,7 +154,7 @@ app.on('window-all-closed', function() {
 
 // Listen to custom protocole incoming messages, needs registering of URL schemes
 app.on('open-url', function (e, url) {
-    console.log('Open URL', url);
+    log.info('Open URL', url);
 });
 
 
@@ -157,7 +170,7 @@ app.on('before-quit', function(event){
     // CLEAR open IPC sockets to geth
     _.each(global.sockets, function(socket){
         if(socket) {
-            console.log('Closing Socket ', socket.id);
+            log.info('Closing socket', socket.id);
             socket.destroy();
         }
     });
@@ -194,7 +207,7 @@ var appStartWindow;
 var nodeType = 'geth';
 var logFunction = function(data) {
     data = data.toString().replace(/[\r\n]+/,'');
-    console.log('NODE LOG:', data);
+    log.trace('NODE LOG:', data);
 
     // if(~data.indexOf('Block synchronisation started') && global.nodes[nodeType]) {
     //     global.nodes[nodeType].stdout.removeListener('data', logFunction);
@@ -203,7 +216,7 @@ var logFunction = function(data) {
 
     // show line if its not empty or "------"
     if(appStartWindow && !/^\-*$/.test(data) && !_.isEmpty(data)) {
-        console.log('"'+ data +'"');
+        log.trace('"'+ data +'"');
         appStartWindow.webContents.send('startScreenText', 'logText', data.replace(/^.*[0-9]\]/,''));
     }
 };
@@ -313,7 +326,7 @@ app.on('ready', function() {
     // ntpClient.getNetworkTime("pool.ntp.org", 123, function(err, date) {
     timesync.checkEnabled(function (err, enabled) {
         if(err) {
-            console.error('Couldn\'t get time from NTP time sync server.', err);
+            log.error('Couldn\'t get time from NTP time sync server.', err);
             return;
         }
 
@@ -348,7 +361,7 @@ app.on('ready', function() {
 
         // try to connect
         socket.on('error', function(e){
-            // console.log('Geth connection REFUSED', count);
+            log.debug('Geth connection REFUSED', count);
 
             // if no geth is running, try starting your own
             if(count === 0) {
@@ -368,8 +381,9 @@ app.on('ready', function() {
                     global.network = fs.readFileSync(global.path.USERDATA + '/network', {encoding: 'utf8'});
                 } catch(e){
                 }
-                console.log('Node type: ', nodeType);
-                console.log('Network: ', global.network);
+
+                log.info('Node type: ', nodeType);
+                log.info('Network: ', global.network);
 
 
                 // If nothing else happens, show an error message in 120 seconds, with the node log text
@@ -432,7 +446,7 @@ app.on('ready', function() {
             }
         });
         socket.on('connect', function(data){
-            console.log('Geth connection FOUND');
+            log.info('Geth connection FOUND');
 
             if(appStartWindow) {
                 if(count === 0)
@@ -476,7 +490,7 @@ app.on('ready', function() {
 
                     ethereumNodes.stopNodes(function(){
                         ethereumNodes.startNode(geth ? 'geth' : 'eth', testnet, function(){
-                            console.log('Changed to ', (testnet ? 'testnet' : 'mainnet'));
+                            log.info('Changed to ', (testnet ? 'testnet' : 'mainnet'));
                             appMenu();
                         });
                     });
@@ -536,7 +550,7 @@ var startMainWindow = function(appStartWindow){
     }
 
     // and load the index.html of the app.
-    console.log('Loading Interface at '+ global.interfaceAppUrl);
+    log.info('Loading Interface at '+ global.interfaceAppUrl);
     global.mainWindow.loadURL(global.interfaceAppUrl);
 
     global.mainWindow.webContents.on('did-finish-load', function() {

--- a/modules/checkNodeSync.js
+++ b/modules/checkNodeSync.js
@@ -9,6 +9,9 @@ const _ = require('underscore');
 const app = require('app');
 const ipc = require('electron').ipcMain;
 
+const log = require('./utils/logger').create('checkNodeSync');
+
+
 // var dechunker = require('./ipc/dechunker.js');
 
 /**
@@ -21,8 +24,7 @@ module.exports = function(appStartWindow, callbackSplash, callbackOnBoarding){
         timeoutId,
         cbCalled = false;
 
-
-    console.log('Checking node sync status...');
+    log.info('Checking node sync status...');
 
     global.nodeConnector.connect();
 
@@ -40,7 +42,7 @@ module.exports = function(appStartWindow, callbackSplash, callbackOnBoarding){
             global.nodeConnector.send('eth_getBlockByNumber', ['latest', false], function(e, result){
                 var now = Math.floor(new Date().getTime() / 1000);
 
-                console.log('Time between last block', (now - +result.timestamp) + 's');
+                log.debug('Time between last block', (now - +result.timestamp) + 's');
 
                 // need sync if > 2 minutes
                 if(now - +result.timestamp > 60 * 2) {
@@ -56,7 +58,7 @@ module.exports = function(appStartWindow, callbackSplash, callbackOnBoarding){
 
                 // start app
                 } else {
-                    console.log('No sync necessary, starting app!');
+                    log.info('No sync necessary, starting app!');
                     callbackSplash();
                     cbCalled = true;
                 }
@@ -72,7 +74,7 @@ module.exports = function(appStartWindow, callbackSplash, callbackOnBoarding){
         if(result.error) {
             // if sync method is not implemented, just start the app
             if(result.error.code === -32601) {
-                console.log('Syncing method not implemented, start app anyway.');
+                log.info('Syncing method not implemented, start app anyway.');
 
                 clearInterval(intervalId);
                 clearTimeout(timeoutId);
@@ -90,7 +92,7 @@ module.exports = function(appStartWindow, callbackSplash, callbackOnBoarding){
 
             // If ready!
             if(now - +result.timestamp < 120 && !cbCalled) {
-                console.log('Sync finished, starting app!');
+                log.info('Sync finished, starting app!');
 
                 clearInterval(intervalId);
                 clearTimeout(timeoutId);

--- a/modules/ethereumNodes.js
+++ b/modules/ethereumNodes.js
@@ -9,6 +9,7 @@ const spawn = require('child_process').spawn;
 const ipc = require('electron').ipcMain;
 const getNodePath = require('./getNodePath.js');
 const popupWindow = require('./popupWindow.js');
+const log = require('./utils/logger').create('ethereumNodes');
 const logRotate = require('log-rotate');
 
 module.exports = {
@@ -18,7 +19,7 @@ module.exports = {
     @method stopNodes
     */
     stopNodes: function(callback) {
-        console.log('Stopping nodes...');
+        log.info('Stopping nodes...');
 
         var node = global.nodes.geth || global.nodes.eth;
 
@@ -67,7 +68,7 @@ module.exports = {
 
         var binPath = getNodePath(type);
 
-        console.log('Start node from '+ binPath);
+        log.info('Start node from '+ binPath);
 
         if(type === 'eth') {
 
@@ -121,9 +122,9 @@ module.exports = {
         // set standard node
         fs.writeFile(global.path.USERDATA + '/node', writeType, function(err) {
             if(!err) {
-                console.log('Saved standard node "'+ writeType +'" to file: '+ global.path.USERDATA + '/node');
+                log.debug('Saved standard node "'+ writeType +'" to file: '+ global.path.USERDATA + '/node');
             } else {
-                console.log(err);
+                log.error(err);
             }
         });
 
@@ -133,9 +134,9 @@ module.exports = {
         // write network type
         fs.writeFile(global.path.USERDATA + '/network', global.network , function(err) {
             if(!err) {
-                console.log('Saved network type "'+ global.network +'" to file: '+ global.path.USERDATA + '/network');
+                log.debug('Saved network type "'+ global.network +'" to file: '+ global.path.USERDATA + '/network');
             } else {
-                console.log(err);
+                log.error(err);
             }
         });
     },
@@ -157,7 +158,7 @@ module.exports = {
 
             _this.stopNodes();
 
-            console.log('Starting '+ type +' node...');
+            log.info('Starting '+ type +' node...');
 
             // wrap the starting callback
             var callCb = function(err, res){
@@ -214,7 +215,7 @@ module.exports = {
                     // set default to geth, to prevent beeing unable to start the wallet
                     _this._writeNodeToFile('geth', testnet);
 
-                    console.log('Password wrong '+ type +' node!');
+                    log.warn('Password wrong '+ type +' node!');
                 }
             });
 

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -8,6 +8,7 @@ Gets the right Node path
 
 const path = require('path');
 const binaryPath = path.resolve(__dirname + '/../nodes');
+const log = require('./utils/logger').create('getNodePath');
 
 // cache
 const resolvedPaths = {};
@@ -45,7 +46,7 @@ module.exports = function(type) {
         resolvedPaths[type] = binPath;
     }
 
-    console.log(`Resolved path for ${type}: ${resolvedPaths[type]}`);
+    log.debug(`Resolved path for ${type}: ${resolvedPaths[type]}`);
 
     return resolvedPaths[type];
 };

--- a/modules/ipc/getIpcPath.js
+++ b/modules/ipc/getIpcPath.js
@@ -4,6 +4,9 @@ Gets the right IPC path
 @module getIpcPath
 */
 
+const log = require('../utils/logger').create('getIpcPath');
+
+
 module.exports = function() {
     var p = require('path');
     var path = global.path.HOME;
@@ -19,6 +22,7 @@ module.exports = function() {
     if(process.platform === 'win32')
         path = '\\\\.\\pipe\\geth.ipc';
     
-    console.log('CONNECT to IPC PATH: '+ path);
+    log.debug('CONNECT to IPC PATH: '+ path);
+
     return path;
 };

--- a/modules/ipc/nodeConnector.js
+++ b/modules/ipc/nodeConnector.js
@@ -4,6 +4,7 @@
 
 const _ = require('underscore');
 const dechunker = require('./dechunker.js');
+const log = require('../utils/logger').create('nodeConnector');
 const net = require('net');
 var idCount = 1;
 
@@ -21,14 +22,14 @@ var NodeConnector = function(ipcPath) {
 
     // error
     this.socket.on('error', function(error){
-        console.log('NODECONNECTOR ERROR', error);
+        log.warn('NODECONNECTOR ERROR', error);
     });
 
     // wait for data on the socket
     this.socket.on('data', function(data){
         dechunker(data, function(error, result){
             if(error) {
-                console.log('NODECONNECTOR TIMEOUT ERROR', error);
+                log.error('NODECONNECTOR TIMEOUT ERROR', error);
                 _.each(_this.callbacks, function(cb){
                     cb(error);
                 });

--- a/modules/ipcCommunicator.js
+++ b/modules/ipcCommunicator.js
@@ -7,6 +7,7 @@ Window communication
 const app = require('app');  // Module to control application life.
 const appMenu = require('./menuItems');   
 const popupWindow = require('./popupWindow.js');
+const log = require('./utils/logger').create('ipcCommunicator');
 const ipc = require('electron').ipcMain;
 
 const _ = global._;
@@ -73,7 +74,7 @@ ipc.on('backendAction_setLanguage', function(e, lang){
         global.i18n.changeLanguage(lang.substr(0,2), function(err, t){
             if(!err) {
                 global.language = global.i18n.language;
-                console.log('Backend language set to: ', global.language);
+                log.info('Backend language set to: ', global.language);
                 appMenu(global.webviews);
             }
         });
@@ -96,7 +97,7 @@ ipc.on('backendAction_importPresaleFile', function(e, path, pw) {
     nodeProcess.stdout.on('data', function(data) {
         var data = data.toString();
         if(data)
-            console.log('Imported presale: ', data);
+            log.info('Imported presale: ', data);
 
         if(/Decryption failed|not equal to expected addr|could not decrypt/.test(data)) {
             e.sender.send('uiAction_importedPresaleFile', 'Decryption Failed');

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -5,6 +5,7 @@ const MenuItem = require('menu-item');
 const Menu = require('menu');
 const shell = require('electron').shell;
 const config = require('../config.js');
+const log = require('./utils/logger').create('menuItems');
 const ipc = require('electron').ipcMain;
 const ethereumNodes = require('./ethereumNodes.js');
 const fs = require('fs');
@@ -228,7 +229,7 @@ var menuTempl = function(webviews) {
                     log = fs.readFileSync(global.path.USERDATA + '/node.log', {encoding: 'utf8'});
                     log = '...'+ log.slice(-1000);
                 } catch(e){
-                    console.log(e);
+                    log.info(e);
                     log = 'Couldn\'t load log file.';
                 };
 
@@ -345,7 +346,7 @@ var menuTempl = function(webviews) {
 
             if(!global.mining) {
                 global.nodeConnector.send('miner_start', [1], function(e, result){
-                    console.log('miner_start', result, e);
+                    log.info('miner_start', result, e);
                     if(result === true) {
                         global.mining = !global.mining;
                         createMenu(webviews);
@@ -353,7 +354,7 @@ var menuTempl = function(webviews) {
                 });
             } else {
                 global.nodeConnector.send('miner_stop', [], function(e, result){
-                    console.log('miner_stop', result, e);
+                    log.info('miner_stop', result, e);
                     if(result === true) {
                         global.mining = !global.mining;
                         createMenu(webviews);

--- a/modules/syncMinimongo.js
+++ b/modules/syncMinimongo.js
@@ -3,6 +3,8 @@
 */
 
 
+const log = require('./utils/logger').create('syncMinimongo');
+
 
 module.exports = function(db, webContents){
 
@@ -40,14 +42,14 @@ module.exports = function(db, webContents){
     ipc.on('minimongo-add', function(event, args) {
 
         if(!db.findOne(args.id)) {
-            // console.log('add', args.id);
+            // log.info('add', args.id);
             args.fields._id = args.id;
             db.insert(args.fields);
         }
     });
     ipc.on('minimongo-changed', function(event, args) {
 
-        // console.log('updated', args.id, args.fields);
+        // log.info('updated', args.id, args.fields);
         db.update(args.id, {$set: args.fields});
     });
     ipc.on('minimongo-removed', function(event, id) {

--- a/modules/utils/logger.js
+++ b/modules/utils/logger.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const _ = require('./underscore');
+const log4js = require('log4js');
+
+
+
+/** 
+ * Setup logging system.
+ * @param  {Object} [options]
+ * @param  {String} [options.loglevel] Minimum logging threshold (default: info).
+ * @param  {String} [options.logfile] File to write logs to (default: no file logging).
+ */
+exports.setup = function(options) {
+    options = _.extend({
+        logfile: null,
+        loglevel: null,
+    }, options);
+
+    // logging
+    const log4jsOptions = {
+        appenders: [ 
+            { 
+                type: 'console',
+            },
+        ],
+        levels: {
+            "[all]": (options.loglevel || 'info').toUpperCase(),
+        }
+    };
+
+    if (options.logfile) {
+        log4jsOptions.appenders.push(
+            { 
+                type: 'file', 
+                filename: options.logfile,
+            }
+        );
+    }
+
+    log4js.configure(log4jsOptions);
+}
+
+
+
+
+exports.create = function(category) {
+    let logger = log4js.getLogger(category);
+
+    // Allow for easy creation of sub-categories.
+    logger.create = function(subCategory) {
+        return exports.create(`${category}/${subCategory}`);
+    }
+
+    return logger;
+};
+
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bignumber.js": "^2.1.4",
     "i18next": "^2.3.4",
     "log-rotate": "^0.2.7",
+    "log4js": "^0.6.35",
     "minimongo-standalone": "0.0.9",
     "numeral": "^1.5.3",
     "os-timesync": "^1.0.3",


### PR DESCRIPTION
This replaces `console.log` calls with a [log4js](https://github.com/nomiddlename/log4js-node) integration and adds two command-line flags (`--loglevel` and `--logfile`) to be able to customize logging verbosity at runtime.

<img width="1111" alt="screen shot 2016-04-18 at 12 26 45" src="https://cloud.githubusercontent.com/assets/266594/14593728/db98be8e-0560-11e6-9c56-51d23abac4b8.png">

Benefits:
* Console output is now timestamped and categorized - with the ability to customize the format in a single place (the `logger.js` file). We could also add a CLI arg to override the pattern if deemed necessary.
* We can now add debug and trace logging in many more parts of the app without automatically clogging up the console output, yet retaining the ability to show these logs by setting the right CLI argument.
* We can set the logging threshold using `--loglevel <level>`. Possible values are `trace`, `debug`, `info`, `warn`, `error`. Default is `info`.
* We can have log4js log to a file using the `--logfile <path to file>` arg.
* Log4js output formatter automatically handles things like `Error` objects well.


I haven't added this logging to the Meteor "interface" app yet but there's no reason we can't do that.