### PR TITLE
Fix Mist startup crash due to about:blank page

### DIFF
--- a/interface/client/appStart.js
+++ b/interface/client/appStart.js
@@ -15,19 +15,25 @@ The init function of Mist
 @method mistInit
 */
 mistInit = function(){
-
+    console.log('Initialise Mist');
 
     Meteor.setTimeout(function() {
+        if (0 <= location.search.indexOf('reset-tabs')) {
+            console.log('Resetting UI tabs');
+            
+            Tabs.remove({});
+        }
+
         if(!Tabs.findOne('browser')) {
             Tabs.insert({
                 _id: 'browser',
-                url: 'about:blank',
+                url: 'https://ethereum.org',
                 position: 0
             });
             
             Tabs.insert({
                 url: 'http://ethereum-dapp-wallet.meteor.com',
-                position: 1,
+                position: 0,
                 permissions: {
                     accounts: web3.eth.accounts
                 }
@@ -41,12 +47,13 @@ mistInit = function(){
 
 
 Meteor.startup(function(){
+    console.log('Meteor starting up');
+
     // check that it is not syncing before
     web3.eth.getSyncing(function(e, sync) {
         if(e || !sync)
             mistInit();
     });
-
 
 
     // SET default language

--- a/main.js
+++ b/main.js
@@ -21,6 +21,7 @@ const argv = require('yargs')
     .describe('gethpath', 'Path to geth executable to use instead of default')
     .describe('ethpath', 'Path to eth executable to use instead of default')
     .describe('ignore-gpu-blacklist', 'Ignores GPU blacklist (needed for some Linux installations)')
+    .describe('reset-tabs', 'Reset Mist tabs to their default settings')
     .describe('logfile', 'Logs will be written to this file')
     .describe('loglevel', 'Minimum logging threshold: trace (all logs), debug, info (default), warn, error')
     .alias('m', 'mode')
@@ -110,9 +111,15 @@ if(global.mode === 'wallet') {
 } else {
     log.info('Starting in Mist mode');
 
-    global.interfaceAppUrl = global.interfacePopupsUrl = (global.production)
+    let url = (global.production)
         ? 'file://' + __dirname + '/interface/index.html'
         : 'http://localhost:3000';
+
+    if (argv.resetTabs) {
+        url += '?reset-tabs=true'
+    }
+
+    global.interfaceAppUrl = global.interfacePopupsUrl = url;
 }
 
 


### PR DESCRIPTION
This fixes the crashes experienced by some OS X users (see #472). 

1. Change `about:blank` to `ethereum.org` for default browser tab in Mist. 
2. Add command-line option to reset Mist interface tabs - a command-line option is required since an in-app GUI option won't be usable if the app keeps crashing.

