### PR TITLE
Add a command line flag --ipcpath (close #600)

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ const argv = require('yargs')
     .describe('ignore-gpu-blacklist', 'Ignores GPU blacklist (needed for some Linux installations)')
     .describe('logfile', 'Logs will be written to this file')
     .describe('loglevel', 'Minimum logging threshold: trace (all logs), debug, info (default), warn, error')
+    .describe('ipcpath', 'Filename for IPC socket/pipe')
     .alias('m', 'mode')
     .help('h')
     .alias('h', 'help')
@@ -56,6 +57,7 @@ global.mode = (argv.mode ? argv.mode : 'mist');
 global.paths = {
     geth: argv.gethpath,
     eth: argv.ethpath,
+    ipc: argv.ipcpath,
 };
 
 global.version = packageJson.version;

--- a/modules/ipc/getIpcPath.js
+++ b/modules/ipc/getIpcPath.js
@@ -11,6 +11,9 @@ module.exports = function() {
     var p = require('path');
     var path = global.path.HOME;
 
+    if(global.paths.ipc)
+        return global.paths.ipc;
+
     if(process.platform === 'darwin')
         path += '/Library/Ethereum/geth.ipc';
 


### PR DESCRIPTION
I have just added the `--ipcpath` command line flag. If specified, mist will use this path for the IPC socket instead of the default one.