### PR TITLE
make log line scanning compatible with geth 1.4

### DIFF
--- a/main.js
+++ b/main.js
@@ -430,7 +430,7 @@ app.on('ready', function() {
                         intervalId = setInterval(function(){
                             if(socket)
                                 socket.connect({path: ipcPath});
-                        }, 200);
+                        }, 500);
 
                         // log data to the splash screen
                         if(global.nodes[nodeType]) {

--- a/modules/ethereumNodes.js
+++ b/modules/ethereumNodes.js
@@ -11,6 +11,8 @@ const getNodePath = require('./getNodePath.js');
 const popupWindow = require('./popupWindow.js');
 const log = require('./utils/logger').create('ethereumNodes');
 const logRotate = require('log-rotate');
+const getIpcPath = require('./ipc/getIpcPath.js');
+var ipcPath = getIpcPath();
 
 module.exports = {
     /**
@@ -175,7 +177,7 @@ module.exports = {
 
             // START TESTNET
             if(testnet) {
-                args = (type === 'geth') ? ['--testnet', '--fast'] : ['--morden', '--unsafe-transactions'];
+                args = (type === 'geth') ? ['--testnet', '--fast', '--ipcpath=' + ipcPath] : ['--morden', '--unsafe-transactions'];
 
             // START MAINNET
             } else {
@@ -245,7 +247,7 @@ module.exports = {
                 if(!cbCalled && _.isFunction(callback)) {
 
                     // (geth) prevent starying until IPC service is started
-                    if(type === 'geth' && data.toString().indexOf('IPC service started') === -1)
+                    if(type === 'geth' && data.toString().indexOf('IPC endpoint opened') === -1)
                         return;
 
                     callCb(null);


### PR DESCRIPTION
When Mist could not find a running node it starts a geth instance in the background. Mist will scan on `stderr` for a line that indicates geth has opened the IPC endpoint. With geth 1.4 this line has changed. This PR changes the line that is is compatible with geth 1.4.

A second modification is made when geth is started for the testnet. Geth 1.4 uses a different location for the IPC endpoint by default then version 1.3. This PR will overrule the default location and set it to the same location as 1.3 did. With this change it is possible to switch between the mainnet and testnet from Mist. 

Note, if a user starts a geth 1.4 testnet instance manually and then starts Mist, Mist won't be able to find the new endpoint since that has changed and will try to start a new geth instance which fails because the p2p port already is claimed. For these cases user must manually specify the IPC endpoint on linux and OSX system. E.g.

`geth --testnet --ipcpath=<datadir>/geth.ipc`