### PR TITLE
update electron-packager to 7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "del": "^1.2.1",
     "easy-zip": "0.0.4",
-    "electron-packager": "^5.2.1",
+    "electron-packager": "^7.0.2",
     "gulp": "^3.9.0",
     "gulp-jszip": "^0.1.2",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
fixes: https://github.com/ethereum/mist/issues/646

I encountered no problems for any platform.
Until PR https://github.com/ethereum/mist/pull/721 is merged into `develop` this will still fail though.