### PR TITLE
Upgrade to web3 version in order to fix broken send tx functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "solc": "^0.3.1-1",
     "underscore": "^1.8.3",
     "uuid": "^2.0.2",
-    "web3": "ethereum/web3.js#0f1ab3227b8985fa5b9cd1fdc75315383f4d7249",
+    "web3": "^0.17.0-alpha",
     "yargs": "^4.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "solc": "^0.3.1-1",
     "underscore": "^1.8.3",
     "uuid": "^2.0.2",
-    "web3": "^0.15.3",
+    "web3": "ethereum/web3.js#0f1ab3227b8985fa5b9cd1fdc75315383f4d7249",
     "yargs": "^4.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Rather than wait for a new web3 version and keep code broken I've fixed the web3 dependency to the specific Git commit - https://github.com/ethereum/web3.js/commit/0f1ab3227b8985fa5b9cd1fdc75315383f4d7249