### PR TITLE
Auto-run gulp update-nodes after npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Now you're ready to install Mist:
     $ cd mist
     $ git submodule update --init
     $ npm install
-    $ gulp update-nodes
 
 To update Mist in the future, run:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/ethereum/mist.git"
   },
   "scripts": {
-    "test": "gulp"
+    "test": "gulp",
+    "postinstall": "gulp update-nodes"
   },
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
Minor improvement, `npm install` will auto-run `gulp update-nodes` once done.