### PR TITLE
Exit app if splash screen is closed

### DIFF
--- a/main.js
+++ b/main.js
@@ -185,6 +185,7 @@ app.on('ready', function() {
     // MIST
     if(global.mode === 'mist') {
         mainWindow = Windows.create('main', {
+            primary: true,
             electronOptions: {
                 width: 1024 + 208,
                 height: 720,
@@ -201,6 +202,7 @@ app.on('ready', function() {
     // WALLET
     } else {
         mainWindow = Windows.create('main', {
+            primary: true,
             electronOptions: {
                 width: 1100,
                 height: 720,
@@ -214,6 +216,7 @@ app.on('ready', function() {
     }
 
     splashWindow = Windows.create('splash', {
+        primary: true,
         url: global.interfacePopupsUrl + '#splashScreen_'+ global.mode,
         show: true,
         electronOptions: {
@@ -313,9 +316,8 @@ app.on('ready', function() {
                     log.info('No accounts setup yet, lets do onboarding first.');
 
                     return new Q((resolve, reject) => {
-                        splashWindow.hide();
-
                         var onboardingWindow = Windows.createPopup('onboardingScreen', {
+                            primary: true,
                             electronOptions: {
                                 width: 576,
                                 height: 442,
@@ -355,6 +357,8 @@ app.on('ready', function() {
 
                             resolve();
                         });
+
+                        splashWindow.hide();
                     });
                 }
             })

--- a/modules/windows.js
+++ b/modules/windows.js
@@ -6,6 +6,7 @@ const EventEmitter = require('events').EventEmitter;
 const log = require('./utils/logger').create('Windows');
 
 const electron = require('electron');
+const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 const ipc = electron.ipcMain;
 
@@ -20,6 +21,7 @@ class Window extends EventEmitter {
 
         this._mgr = mgr;
         this._log = log.create(type);
+        this.isPrimary = !!opts.primary;
         this.type = type;
         this.isPopup = !!opts.isPopup;
         this.ownerId = opts.ownerId;
@@ -61,7 +63,7 @@ class Window extends EventEmitter {
             }
 
             if (opts.show) {
-                this.window.show();
+                this.show();
             }
 
             this.emit('ready');
@@ -70,10 +72,9 @@ class Window extends EventEmitter {
         this.window.once('closed', () => {
             this._log.debug(`Closed`);
 
+            this.isShown = false;
             this.isClosed = true;
             this.isContentReady = false;
-
-            delete this._mgr._windows[this.type];
 
             this.emit('closed');
         });
@@ -127,6 +128,8 @@ class Window extends EventEmitter {
         this._log.debug(`Hide`);
 
         this.window.hide();
+
+        this.isShown = false;
     }
 
 
@@ -138,6 +141,8 @@ class Window extends EventEmitter {
         this._log.debug(`Show`);
 
         this.window.show();
+
+        this.isShown = true;
     }
 
 
@@ -216,9 +221,13 @@ class Windows {
             return existing;
         }
 
-        log.info(`Create window: ${type}, owner: ${options.ownerId || 'notset'}`);
+        let category = options.primary ? 'primary' : 'secondary';
+
+        log.info(`Create ${category} window: ${type}, owner: ${options.ownerId || 'notset'}`);
 
         let wnd = this._windows[type] = new Window(this, type, options);
+
+        wnd.on('closed', this._onWindowClosed.bind(this, wnd));
 
         return wnd;
     }
@@ -306,6 +315,39 @@ class Windows {
         _.each(this._windows, (wnd) => {
             wnd.send.apply(wnd, data);
         });
+    }
+
+
+    /**
+     * Handle a window being closed.
+     *
+     * This will remove the window from the internal list.
+     *
+     * This also checks to see if any primary windows are still visible 
+     * (even if hidden). If none found then it quits the app.
+     *
+     * @param {Window} wnd
+     */
+    _onWindowClosed (wnd) {
+        log.debug(`Removing window from list: ${wnd.type}`);
+
+        for (let t in this._windows) {
+            if (this._windows[t] === wnd) {
+                delete this._windows[t];
+
+                break;
+            }
+        }
+
+        let anyOpen = _.find(this._windows, (wnd) => {
+            return wnd.isPrimary && !wnd.isClosed && wnd.isShown;
+        });
+
+        if (!anyOpen) {
+            log.info('All primary windows closed/invisible, so quitting app...');
+
+            app.quit();
+        }
     }
 }
 


### PR DESCRIPTION
This adds logic to the window manager which keeps track of _primary_ windows which are visible. As soon as none are visible we quite the app. Primary windows are explicitly marked as such - splash, onboarding, main.