### PR TITLE
readme: no 'gulp update-nodes' needed after 'npm install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Now you're ready to install Mist:
     $ cd mist
     $ git submodule update --init
     $ npm install
-    $ gulp update-nodes
 
 To update Mist in the future, run:
 


### PR DESCRIPTION
@I overlooked that `gulp update-nodes` is already triggered during `npm install` ([package.json#L11](https://github.com/ethereum/mist/blob/develop/package.json#L11)).