### PR TITLE
change binary name "Ethereum-Wallet" to "Ethereum Wallet"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -113,7 +113,7 @@ gulp.task('set-variables-mist', function () {
 gulp.task('set-variables-wallet', function () {
     type = 'wallet';
     filenameLowercase = 'ethereum-wallet';
-    filenameUppercase = 'Ethereum-Wallet';
+    filenameUppercase = 'Ethereum Wallet';
     applicationName = 'Ethereum Wallet';
 });
 


### PR DESCRIPTION
`0.7.5` used **Ethereum Wallet** while
`0.7.6` used **Ethereum-Wallet** again
as reported in https://github.com/ethereum/mist/issues/881 (OSX app consistent naming)

This PR closes https://github.com/ethereum/mist/issues/833.

Tested on OSX 10.11.5, Ubuntu 14.04 and Windows 7 x64.