### PR TITLE
update-popup-window: prevent maximize

### DIFF
--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -73,6 +73,7 @@ function showWindow(options) {
             width: 420, 
             height: 230 ,
             alwaysOnTop: true,
+            maximizable: false,
         },
     }, options));
 }

--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -73,6 +73,7 @@ function showWindow(options) {
             width: 420, 
             height: 230 ,
             alwaysOnTop: true,
+            resizable: false,
             maximizable: false,
         },
     }, options));


### PR DESCRIPTION
This will prevent the update window to be maximized.

Please try this PR with electron `1.2.5` as a bug prevents this from working in `1.2.2`.
This bug has been fixed in electron `1.2.3` https://github.com/electron/electron/pull/5944 (*Fix maximizable: false not working for frameless window*)
Though the wallet/mist won't work with `1.2.3` due to some other bug fixed in `1.2.4` or `1.2.5`. ;-)

---

Also added `resizable: false`, though it is still broken in `1.2.5`.