### PR TITLE
remove duplicate 'gulp update-nodes'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_script:
   - "npm install"
   - "npm install -g electron-prebuilt@1.0.1"
   - "npm install -g meteor-build-client"
-  - "gulp update-nodes"
 
 script:
   - "npm test"


### PR DESCRIPTION
This is already run as hook after `npm install`: [package.json#L11](https://github.com/ethereum/mist/blob/develop/package.json#L11).