### PR TITLE
fixed webview tagd and updated electrong to 1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Once a Mist version is released the Meteor frontend part is bundled using `meteo
 
 Requirements: 
 
-* Electron v1.2.2
+* Electron v1.2.5
 * Node v4.3.0 or above
 
 To run mist in development you need [Node.js NPM](https://nodejs.org) and [Meteor](https://www.meteor.com/install) and electron installed:
 
     $ curl https://install.meteor.com/ | sh
-    $ npm install -g electron-prebuilt@1.2.2
+    $ npm install -g electron-prebuilt@1.2.5
     $ npm install -g gulp
 
 ### Installation

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,7 @@ var type = 'mist';
 var filenameLowercase = 'mist';
 var filenameUppercase = 'Mist';
 var applicationName = 'Mist'; 
-var electronVersion = '1.2.2';
+var electronVersion = '1.2.5';
 var gethVersion = '1.4.7';
 var nodeUrls = {
     'darwin-x64': 'https://github.com/ethereum/go-ethereum/releases/download/v1.4.7/geth-OSX-2016061509421-1.4.7-667a386.zip',

--- a/main.js
+++ b/main.js
@@ -190,6 +190,7 @@ app.on('ready', function() {
                 width: 1024 + 208,
                 height: 720,
                 webPreferences: {
+                    nodeIntegration: true,
                     preload: __dirname +'/modules/preloader/mistUI.js',
                     'overlay-fullscreen-video': true,
                     'overlay-scrollbars': true

--- a/modules/preloader/mistUI.js
+++ b/modules/preloader/mistUI.js
@@ -38,6 +38,12 @@ window.syncMinimongo = syncMinimongo;
 window.ipc = ipc;
 
 
+// remove require and modules, when node-integration is on
+delete window.module;
+delete window.require;
+
+
+
 // prevent overwriting the Dapps Web3
 delete global.Web3;
 delete window.Web3;


### PR DESCRIPTION
This updates electron to 1.2.5 and also fixes the web view issue, where i had to enable `nodeIntegration` while also removing the require and module object in the preloaded