### PR TITLE
#928 update README.md - remove 'gulp update-nodes' after 'npm install' as …

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,12 @@ Now you're ready to install Mist:
     $ cd mist
     $ git submodule update --init
     $ npm install
-    $ gulp update-nodes
 
 To update Mist in the future, run:
 
     $ cd mist
     $ git pull && git submodule update
     $ npm install
-    $ gulp update-nodes
 
 
 ### Run Mist


### PR DESCRIPTION
…it's run in 'npm install' postInstall anyway