### PR TITLE
Refactor minimongo sync to avoid storing data in browser localStorage

### DIFF
--- a/interface/client/collections.js
+++ b/interface/client/collections.js
@@ -10,7 +10,7 @@
 Tabs = new Mongo.Collection('tabs', {connection: null});
 
 if (typeof syncMinimongo !== 'undefined')
-    syncMinimongo(Tabs);
+    syncMinimongo.frontendSync(Tabs);
 
 
 // Contains the address book

--- a/interface/client/collections.js
+++ b/interface/client/collections.js
@@ -9,8 +9,9 @@
 // Contains the accounts
 Tabs = new Mongo.Collection('tabs', {connection: null});
 
-if (typeof syncMinimongo !== 'undefined')
-    syncMinimongo.frontendSync(Tabs);
+if (typeof window.mist.syncMinimongo !== 'undefined') {
+    window.mist.syncMinimongo.frontendSync(Tabs);
+}
 
 
 // Contains the address book

--- a/interface/client/collections.js
+++ b/interface/client/collections.js
@@ -4,12 +4,12 @@
 */
 
 
+
 // BROWSER RELATED
 // Contains the accounts
 Tabs = new Mongo.Collection('tabs', {connection: null});
-pers = new PersistentMinimongo2(Tabs, 'Mist');
 
-if(typeof syncMinimongo !== 'undefined')
+if (typeof syncMinimongo !== 'undefined')
     syncMinimongo(Tabs);
 
 

--- a/interface/client/lib/thirdParty.js
+++ b/interface/client/lib/thirdParty.js
@@ -1,5 +1,3 @@
-
-
 // set spinner options
 Meteor.Spinner.options = {
     lines: 12, // The number of lines to draw

--- a/interface/client/templates/layout/sidebar.js
+++ b/interface/client/templates/layout/sidebar.js
@@ -74,7 +74,7 @@ Template['layout_sidebar'].helpers({
         var template = Template.instance();
 
         if(this._id === 'browser') {
-            return Tabs.find({},{sort: {timestamp: -1}, limit: 25});
+            return DoogleLastVisitedPages.find({},{sort: {timestamp: -1}, limit: 25});
 
         } else if(this.menu) {
             var menu = _.toArray(this.menu);

--- a/interface/client/templates/layout/sidebar.js
+++ b/interface/client/templates/layout/sidebar.js
@@ -74,7 +74,7 @@ Template['layout_sidebar'].helpers({
         var template = Template.instance();
 
         if(this._id === 'browser') {
-            return DoogleLastVisitedPages.find({},{sort: {timestamp: -1}, limit: 25});
+            return Tabs.find({},{sort: {timestamp: -1}, limit: 25});
 
         } else if(this.menu) {
             var menu = _.toArray(this.menu);

--- a/interface/client/templates/popupWindows/splashScreen.html
+++ b/interface/client/templates/popupWindows/splashScreen.html
@@ -6,7 +6,7 @@
             <button class="start-app">{{{TemplateVar.get "startAppButtonText"}}}</button>
         {{/if}}
 
-        <img id="image" src="{{iconPath}}">
+        <img id="image" src="{{appIconPath}}">
         <h1>
             {{{TemplateVar.get "text"}}}
             

--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ const Settings = require('./modules/settings');
 Settings.init();
 
 
+
 if (Settings.cli.version) {
     console.log(Settings.appVersion);
 
@@ -36,12 +37,19 @@ if (Settings.cli.ignoreGpuBlacklist) {
     app.commandLine.appendSwitch('ignore-gpu-blacklist', 'true');
 }
 
+
+
 // logging setup
 const log = logger.create('main');
 
 if (Settings.inTestMode) {
     log.info('TEST MODE');
 }
+
+
+// db
+const db = global.db = require('./modules/db');
+
 
 // GLOBAL Variables
 global.path = {
@@ -80,7 +88,6 @@ global.icon = __dirname +'/icons/'+ global.mode +'/icon.png';
 global.language = 'en';
 global.i18n = i18n; // TODO: detect language switches somehow
 
-global.Tabs = Minimongo('tabs');
 
 
 // INTERFACE PATHS
@@ -162,8 +169,6 @@ app.on('before-quit', function(event){
 });
 
 
-
-
 var mainWindow;
 var splashWindow;
 
@@ -171,6 +176,17 @@ var splashWindow;
 // This method will be called when Electron has done everything
 // initialization and ready for creating browser windows.
 app.on('ready', function() {
+    // initialise the db
+    global.db.init().then(onReady).catch((err) => {
+        log.error(err);
+
+        app.quit();
+    });
+});
+
+
+
+var onReady = function() {
     // Initialise window mgr
     Windows.init();
 
@@ -206,7 +222,7 @@ app.on('ready', function() {
             }
         });
 
-        syncMinimongo(Tabs, mainWindow.webContents);
+        syncMinimongo(global.db.Tabs, mainWindow);
 
     // WALLET
     } else {
@@ -401,7 +417,7 @@ app.on('ready', function() {
         kickStart();
     }
 
-}); /* on app ready */
+}; /* onReady() */
 
 
 
@@ -428,9 +444,17 @@ var startMainWindow = function() {
         app.quit();
     });
 
-    // instantiate the application menu
-    Tracker.autorun(function(){
-        global.webviews = Tabs.find({},{sort: {position: 1}, fields: {name: 1, _id: 1}}).fetch();
+    // observe Tabs for changes and refresh menu
+    let sortedTabs = global.db.Tabs.addDynamicView('sorted_tabs');
+    sortedTabs.applySimpleSort('position', false);
+
+    let refreshMenu = function() {
+        global.webviews = sortedTabs.data();
+
         appMenu(global.webviews);
-    });
+    };
+
+    global.db.Tabs.on('insert', refreshMenu);
+    global.db.Tabs.on('update', refreshMenu);
+    global.db.Tabs.on('delete', refreshMenu);
 };

--- a/main.js
+++ b/main.js
@@ -432,11 +432,15 @@ var startMainWindow = function() {
     sortedTabs.applySimpleSort('position', false);
 
     let refreshMenu = function() {
-        log.debug('Refresh menu with tabs');
+        clearTimeout(global._refreshMenuFromTabsTimer);
 
-        global.webviews = sortedTabs.data();
+        global._refreshMenuFromTabsTimer = setTimeout(function() {
+            log.debug('Refresh menu with tabs');
 
-        appMenu(global.webviews);
+            global.webviews = sortedTabs.data();
+
+            appMenu(global.webviews);            
+        }, 200);
     };
 
     global.db.Tabs.on('insert', refreshMenu);

--- a/main.js
+++ b/main.js
@@ -12,7 +12,6 @@ const electron = require('electron');
 const app = electron.app;
 const dialog = electron.dialog;
 const timesync = require("os-timesync");
-const Minimongo = require('./modules/minimongoDb.js');
 const syncMinimongo = require('./modules/syncMinimongo.js');
 const ipc = electron.ipcMain;
 const packageJson = require('./package.json');

--- a/main.js
+++ b/main.js
@@ -170,6 +170,9 @@ app.on('ready', function() {
 
 
 var onReady = function() {
+    // sync minimongo
+    syncMinimongo.backendSync(global.db.Tabs);
+
     // Initialise window mgr
     Windows.init();
 
@@ -204,8 +207,6 @@ var onReady = function() {
                 }
             }
         });
-
-        syncMinimongo.backendSync(global.db.Tabs, mainWindow);
 
     // WALLET
     } else {

--- a/modules/db.js
+++ b/modules/db.js
@@ -1,0 +1,34 @@
+const Loki = require('loki');
+const Settings = require('./settings');
+const path = require('path');
+const Q = require('bluebird');
+const log = require('./utils/logger').create('Db');
+
+
+
+exports.init = function() {
+  return new Q((resolve, reject) => {
+    let db = new Loki(path.join(Settings.userDataPath, 'mist_settings.db'), {
+      env: 'NODEJS',
+      autosave: true,
+      autosaveInterval: 5000,
+      autoload: true,
+      autoloadCallback: function(err) {
+        if (err) {
+          log.error(err);
+
+          reject(new Error('Error instantiating local filesystem db'));
+        }
+
+        if (!db.getCollection('tabs')) {
+          db.addCollection('tabs');
+        }
+
+        exports.Tabs = db.getCollection('tabs');
+
+        resolve();
+      }
+    });
+  });
+};
+

--- a/modules/db.js
+++ b/modules/db.js
@@ -1,34 +1,77 @@
-const Loki = require('loki');
+const Loki = require('lokijs');
 const Settings = require('./settings');
 const path = require('path');
 const Q = require('bluebird');
 const log = require('./utils/logger').create('Db');
+const fs = require('fs');
 
+
+let db;
 
 
 exports.init = function() {
+  const filePath = path.join(Settings.userDataPath, 'mist.lokidb');
+
+  return Q.try(() => {
+    // if db file doesn't exist then create it
+    try {
+      log.debug(`Check that db exists: ${filePath}`);
+
+      fs.accessSync(filePath, fs.R_OK);
+
+      return Q.resolve();
+    } catch (err) {
+      log.info(`Creating db: ${filePath}`);
+
+      let tempdb = new Loki(filePath, {
+        env: 'NODEJS',
+        autoload: false,
+      });
+
+      return new Q.promisify(tempdb.saveDatabase, {context: tempdb})();
+    }
+  })
+  .then(() => {
+    log.info(`Loading db: ${filePath}`);
+
+    return new Q((resolve, reject) => {
+      db = new Loki(filePath, {
+        env: 'NODEJS',
+        autosave: true,
+        autosaveInterval: 5000,
+        autoload: true,
+        autoloadCallback: function(err) {
+          if (err) {
+            log.error(err);
+
+            reject(new Error('Error instantiating db'));
+          }
+
+          if (!db.getCollection('tabs')) {
+            db.addCollection('tabs');
+          }
+
+          exports.Tabs = db.getCollection('tabs');
+
+          resolve();
+        }
+      });      
+    });
+  })
+};
+
+
+
+exports.close = function() {
   return new Q((resolve, reject) => {
-    let db = new Loki(path.join(Settings.userDataPath, 'mist_settings.db'), {
-      env: 'NODEJS',
-      autosave: true,
-      autosaveInterval: 5000,
-      autoload: true,
-      autoloadCallback: function(err) {
-        if (err) {
-          log.error(err);
-
-          reject(new Error('Error instantiating local filesystem db'));
-        }
-
-        if (!db.getCollection('tabs')) {
-          db.addCollection('tabs');
-        }
-
-        exports.Tabs = db.getCollection('tabs');
-
+    db.close((err) => {
+      if (err) {
+        reject(err);
+      } else {
         resolve();
       }
     });
   });
 };
+
 

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -532,7 +532,7 @@ class EthereumNode extends EventEmitter {
 
 
     _buildFilePath (path) {
-        return global.path.USERDATA + '/' + path;   
+        return Settings.userDataPath + '/' + path;   
     }
 
 }

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -29,11 +29,11 @@ module.exports = function(type) {
     if (globallySetType) {
         resolvedPaths[type] = globallySetType;
     } else {
-        var binPath = (global.production)
+        var binPath = (Settings.inProductionMode)
             ? binaryPath.replace('nodes','node') + '/'+ type +'/'+ type
             : binaryPath + '/'+ type +'/'+ process.platform +'-'+ process.arch + '/'+ type;
 
-        if(global.production) {
+        if(Settings.inProductionMode) {
             binPath = binPath.replace('app.asar/','').replace('app.asar\\','');
             
             if(process.platform === 'darwin') {

--- a/modules/ipc/getIpcPath.js
+++ b/modules/ipc/getIpcPath.js
@@ -16,7 +16,7 @@ module.exports = function() {
     }
     
     var p = require('path');
-    var path = global.path.HOME;
+    var path = Settings.userHomePath;
 
     if(process.platform === 'darwin') {
         path += '/Library/Ethereum/geth.ipc';

--- a/modules/ipc/methods/base.js
+++ b/modules/ipc/methods/base.js
@@ -79,7 +79,7 @@ module.exports = class BaseProcessor {
     _isAdminConnection (conn) {
         // main window or popupwindows - always allow requests
         let wnd = Windows.getById(conn.id);
-        let tab = Tabs.findOne({ webviewId: conn.id });
+        let tab = global.db.Tabs.findOne({ webviewId: conn.id });
 
         return ((wnd && ('main' === wnd.type || wnd.isPopup)) ||
                 (tab && _.get(tab, 'permissions.admin') === true));

--- a/modules/ipc/methods/eth_accounts.js
+++ b/modules/ipc/methods/eth_accounts.js
@@ -3,7 +3,6 @@
 const _ = global._;
 const BaseProcessor = require('./base');
 
-
 /**
  * Process method: eth_accounts
  */
@@ -18,7 +17,7 @@ module.exports = class extends BaseProcessor {
 
             // if not an admin connection then do a check
             if (!this._isAdminConnection(conn)) {
-                let tab = Tabs.findOne({ webviewId: conn.id });
+                let tab = global.db.Tabs.findOne({ webviewId: conn.id });
 
                 if(_.get(tab, 'permissions.accounts')) {
                     ret.result = _.intersection(ret.result, tab.permissions.accounts);

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -9,6 +9,7 @@ const ipc = electron.ipcMain;
 const ethereumNode = require('./ethereumNode.js');
 const Windows = require('./windows');
 const updateChecker = require('./updateChecker');
+const Settings = require('./settings');
 const fs = require('fs');
 const dialog = electron.dialog;
 
@@ -49,10 +50,10 @@ var menuTempl = function(webviews) {
 
     // APP
     menu.push({
-        label: i18n.t('mist.applicationMenu.app.label', {app: global.appName}),
+        label: i18n.t('mist.applicationMenu.app.label', {app: Settings.appName}),
         submenu: [
             {
-                label: i18n.t('mist.applicationMenu.app.about', {app: global.appName}),
+                label: i18n.t('mist.applicationMenu.app.about', {app: Settings.appName}),
                 click: function(){
                     Windows.createPopup('about', {
                         electronOptions: {
@@ -72,7 +73,7 @@ var menuTempl = function(webviews) {
                 type: 'separator'
             },
             {
-                label: i18n.t('mist.applicationMenu.app.services', {app: global.appName}),
+                label: i18n.t('mist.applicationMenu.app.services', {app: Settings.appName}),
                 role: 'services',
                 submenu: []
             },
@@ -80,24 +81,24 @@ var menuTempl = function(webviews) {
                 type: 'separator'
             },
             {
-                label: i18n.t('mist.applicationMenu.app.hide', {app: global.appName}),
+                label: i18n.t('mist.applicationMenu.app.hide', {app: Settings.appName}),
                 accelerator: 'Command+H',
                 role: 'hide'
             },
             {
-                label: i18n.t('mist.applicationMenu.app.hideOthers', {app: global.appName}),
+                label: i18n.t('mist.applicationMenu.app.hideOthers', {app: Settings.appName}),
                 accelerator: 'Command+Alt+H',
                 role: 'hideothers'
             },
             {
-                label: i18n.t('mist.applicationMenu.app.showAll', {app: global.appName}),
+                label: i18n.t('mist.applicationMenu.app.showAll', {app: Settings.appName}),
                 role: 'unhide'
             },
             {
                 type: 'separator'
             },
             {
-                label: i18n.t('mist.applicationMenu.app.quit', {app: global.appName}),
+                label: i18n.t('mist.applicationMenu.app.quit', {app: Settings.appName}),
                 accelerator: 'CommandOrControl+Q',
                 click: function(){
                     app.quit();
@@ -142,12 +143,12 @@ var menuTempl = function(webviews) {
                     {
                         label: i18n.t('mist.applicationMenu.accounts.backupKeyStore'),
                         click: function(){
-                            var path = global.path.HOME;
+                            var path = Settings.userHomePath;
 
                             // eth
                             if(ethereumNode.isEth) {
                                 if(process.platform === 'win32')
-                                    path = global.path.APPDATA + '\\Web3\\keys';
+                                    path = Settings.appDataPath + '\\Web3\\keys';
                                 else
                                     path += '/.web3/keys';
 
@@ -162,7 +163,7 @@ var menuTempl = function(webviews) {
                                     path += '/.ethereum/keystore';
 
                                 if(process.platform === 'win32')
-                                    path = global.path.APPDATA + '\\Ethereum\\keystore';
+                                    path = Settings.appDataPath + '\\Ethereum\\keystore';
                             }
 
                             shell.showItemInFolder(path);
@@ -170,7 +171,7 @@ var menuTempl = function(webviews) {
                     },{
                         label: i18n.t('mist.applicationMenu.accounts.backupMist'),
                         click: function(){
-                            shell.showItemInFolder(global.path.USERDATA);
+                            shell.showItemInFolder(Settings.userDataPath);
                         }
                     }
                 ]
@@ -270,7 +271,7 @@ var menuTempl = function(webviews) {
     var devToolsMenu = [];
 
     // change for wallet
-    if(global.mode === 'mist') {
+    if(Settings.uiMode === 'mist') {
         devtToolsSubMenu = [{
             label: i18n.t('mist.applicationMenu.develop.devToolsMistUI'),
             accelerator: 'Alt+CommandOrControl+I',
@@ -309,7 +310,7 @@ var menuTempl = function(webviews) {
             submenu: devtToolsSubMenu
         },{
             label: i18n.t('mist.applicationMenu.develop.runTests'),
-            enabled: (global.mode === 'mist'),
+            enabled: (Settings.uiMode === 'mist'),
             click: function(){
                 Windows.getByType('main').send('runTests', 'webview');
             }
@@ -318,7 +319,7 @@ var menuTempl = function(webviews) {
             click: function(){
                 var log = '';
                 try {
-                    log = fs.readFileSync(global.path.USERDATA + '/node.log', {encoding: 'utf8'});
+                    log = fs.readFileSync(Settings.userDataPath + '/node.log', {encoding: 'utf8'});
                     log = '...'+ log.slice(-1000);
                 } catch(e){
                     log.info(e);

--- a/modules/minimongoDb.js
+++ b/modules/minimongoDb.js
@@ -1,9 +1,0 @@
-
-module.exports = function(dbName) {
-    // make minimongo available
-    require('../node_modules/minimongo-standalone/minimongo.js');
-    
-    db = new LocalCollection(dbName, {connection: null});
-
-    return db;
-};

--- a/modules/mistAPI.js
+++ b/modules/mistAPI.js
@@ -4,6 +4,7 @@
 
 const electron = require('electron');
 const packageJson = require('./../package.json');
+const syncMinimongo = require('./syncMinimongo.js');
 const remote = electron.remote;
 const ipc = electron.ipcRenderer;
 
@@ -67,6 +68,7 @@ module.exports = function(isWallet) {
     */
     
     var mist = {
+        syncMinimongo: syncMinimongo,
         callbacks: {},
         dirname: remote.getGlobal('dirname'),
         version: packageJson.version,

--- a/modules/preloader/mistUI.js
+++ b/modules/preloader/mistUI.js
@@ -5,7 +5,6 @@
 require('./include/common')('mist');
 const electron = require('electron');
 const ipc = electron.ipcRenderer;
-const syncMinimongo = require('../syncMinimongo.js');
 const remote = electron.remote;
 const Menu = remote.Menu;
 const MenuItem = remote.MenuItem;
@@ -34,7 +33,6 @@ setTimeout(function(){
 }, 1000);
 
 window.mist = mist();
-window.syncMinimongo = syncMinimongo;
 window.ipc = ipc;
 
 

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -1,3 +1,6 @@
+const electron = require('electron');
+const app = electron.app;
+
 const logger = require('./utils/logger');
 const packageJson = require('../package.json');
 
@@ -153,7 +156,17 @@ class Settings {
   }
 
   get userDataPath() {
-    return global.path.USERDATA;
+    // Application Aupport/Mist
+    return app.getPath('userData');
+  }
+
+  get appDataPath() {
+    // Application Support/
+    return app.getPath('appData');
+  }
+
+  get userHomePath() {
+    return app.getPath('home');
   }
 
   get cli () {
@@ -162,6 +175,10 @@ class Settings {
 
   get appVersion () {
     return packageJson.version;
+  }
+
+  get appName () {
+    return 'mist' === this.uiMode ? 'Mist' : 'Ethereum Wallet';
   }
 
   get appLicense () {
@@ -176,7 +193,7 @@ class Settings {
     return defaultConfig.production;
   }
 
-  get inTestMode () {
+  get inAutoTestMode () {
     return !!process.env.TEST_MODE;
   }
 

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -152,6 +152,10 @@ class Settings {
     this._log = logger.create('Settings');    
   }
 
+  get userDataPath() {
+    return global.path.USERDATA;
+  }
+
   get cli () {
     return argv;
   }

--- a/modules/syncMinimongo.js
+++ b/modules/syncMinimongo.js
@@ -9,9 +9,8 @@ var electron = require('electron');
 /**
  * Sync IPC calls received from given window into given db table.
  * @param  {Object} coll Db collection to save to.
- * @param  {Window} wnd     Window to listen to.
  */
-exports.backendSync = function(coll, wnd) {
+exports.backendSync = function(coll) {
     var log = require('./utils/logger').create('syncMinimongo/' + coll.name);
 
     var ipc = electron.ipcMain;

--- a/modules/syncMinimongo.js
+++ b/modules/syncMinimongo.js
@@ -3,59 +3,79 @@
 */
 
 
-const log = require('./utils/logger').create('syncMinimongo');
-
 const electron = require('electron');
 
 
-module.exports = function(db, webContents){
+module.exports = function(db, wnd){
 
-    var ipc = (webContents) ? electron.ipcMain : electron.ipcRenderer;
+    var log = (wnd) 
+        ? require('./utils/logger').create('syncMinimongo/' + db._name)
+        : console;
 
-
-    // ONLY syncs from Mist UI to backend, not down again.
+    var sendTarget = wnd || electron.ipcRenderer;
 
     // send
     db.find().observeChanges({
-        'added': function(id, fields){
-            // if(webContents && !webContents.isDestroyed())
-            //     webContents.send('minimongo-add', {id: id, fields: fields});
-            // else
-            if(!webContents)
-                ipc.send('minimongo-add', {id: id, fields: fields});
+        'added': function(id, fields){            
+            sendTarget.send('minimongo-add', {id: id, fields: fields});
         },
         'changed': function(id, fields){
-            // if(webContents && !webContents.isDestroyed())
-            //     webContents.send('minimongo-changed', {id: id, fields: fields});
-            // else
-            if(!webContents)
-                ipc.send('minimongo-changed', {id: id, fields: fields});
+            sendTarget.send('minimongo-changed', {id: id, fields: fields});
         },
         removed: function(id) {
-            // if(webContents && !webContents.isDestroyed())
-            //     webContents.send('minimongo-removed', id);
-            // else
-            if(!webContents)
-                ipc.send('minimongo-removed', id);
+            sendTarget.send('minimongo-removed', id);
         }
     });
 
     // receive
-    ipc.on('minimongo-add', function(event, args) {
 
-        if(!db.findOne(args.id)) {
-            // log.info('add', args.id);
+    var ipc = (wnd) ? electron.ipcMain : electron.ipcRenderer;
+
+    ipc.on('minimongo-add', function(event, args) {
+        log.trace('minimongo-add', args);
+
+        if (!db.findOne(args.id)) {
             args.fields._id = args.id;
+
             db.insert(args.fields);
         }
     });
-    ipc.on('minimongo-changed', function(event, args) {
 
-        // log.info('updated', args.id, args.fields);
+    ipc.on('minimongo-changed', function(event, args) {
+        log.trace('minimongo-changed', args);
+
         db.update(args.id, {$set: args.fields});
     });
+
     ipc.on('minimongo-removed', function(event, id) {
+        log.trace('minimongo-removed', id);
 
         db.remove(id.toString());
     });
+
+    // get all data (synchronous)
+    ipc.on('minimongo-reloadSync', function(event) {
+        var docs = db.find({}).fetch();
+
+        log.debug('minimongo-reloadSync, no. of docs:', docs.length);
+
+        event.returnValue = JSON.stringify(docs);
+    });
+
+    // Frontend should reload all data from back-end at startup
+    if (!wnd) {
+        let dataStr = electron.ipcRenderer.sendSync('minimongo-reloadSync');
+
+        if (dataStr) {
+            log.debug('Repopulate db with minimongo-reloadSync data');
+
+            db.remove({});
+
+            JSON.parse(dataStr).forEach(function(record) {
+                db.insert(record);
+            });
+        }
+    }
 };
+
+

--- a/modules/syncMinimongo.js
+++ b/modules/syncMinimongo.js
@@ -90,7 +90,7 @@ exports.frontendSync = function(coll) {
     let dataStr = ipc.sendSync('minimongo-reloadSync');
 
     if (dataStr) {
-        console.debug('Repopulate collection with backend data', coll._name);
+        console.debug('Repopulate collection with backend data: ', coll._name);
 
         coll.remove({});
 

--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -5,7 +5,7 @@ const got = require('got');
 const semver = require('semver');
 const Windows = require('./windows');
 const log = require('./utils/logger').create('updateChecker');
-
+const Settings = require('./settings');
 
 
 /**
@@ -17,7 +17,7 @@ const check = exports.check = function() {
 
     let str = null;
 
-    switch (global.mode) {
+    switch (Settings.uiMode) {
         case 'mist':
             str = 'mist';
             break;
@@ -46,8 +46,8 @@ const check = exports.check = function() {
 
         let latest = releases[0];
 
-        if (semver.gt(latest.tag_name, global.version)) {
-            log.info(`App (v${global.version}) is out of date. New v${latest.tag_name} found.`);
+        if (semver.gt(latest.tag_name, Settings.appVersion)) {
+            log.info(`App (v${Settings.appVersion}) is out of date. New v${latest.tag_name} found.`);
 
             return {
                 name: latest.name,

--- a/modules/windows.js
+++ b/modules/windows.js
@@ -107,7 +107,7 @@ class Window extends EventEmitter {
     }
 
     send () {
-        if (!this.isContentReady) { 
+        if (this.isClosed || !this.isContentReady) { 
             return;
         }
 

--- a/modules/windows.js
+++ b/modules/windows.js
@@ -5,6 +5,8 @@ const Q = require('bluebird');
 const EventEmitter = require('events').EventEmitter;
 const log = require('./utils/logger').create('Windows');
 
+const Settings = require('./settings');
+
 const electron = require('electron');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
@@ -27,7 +29,7 @@ class Window extends EventEmitter {
         this.ownerId = opts.ownerId;
 
         let electronOptions = {
-            title: global.appName,
+            title: Settings.appName,
             show: false,
             width: 1100,
             height: 720,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,21 @@
 {
   "name": "Mist",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
       "from": "abbrev@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+    },
+    "amdefine": {
+      "version": "1.0.0",
+      "from": "amdefine@>=0.0.4",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
@@ -22,10 +32,67 @@
       "from": "archive-type@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz"
     },
+    "archiver": {
+      "version": "0.14.4",
+      "from": "archiver@>=0.14.3 <0.15.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "end-of-stream": {
+          "version": "1.1.0",
+          "from": "end-of-stream@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+        },
+        "glob": {
+          "version": "4.3.5",
+          "from": "glob@>=4.3.0 <4.4.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz"
+        },
+        "lazystream": {
+          "version": "0.1.0",
+          "from": "lazystream@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz"
+        },
+        "lodash": {
+          "version": "3.2.0",
+          "from": "lodash@>=3.2.0 <3.3.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@^2.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        },
+        "tar-stream": {
+          "version": "1.1.5",
+          "from": "tar-stream@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz"
+        }
+      }
+    },
     "archy": {
       "version": "1.0.0",
       "from": "archy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+    },
+    "argparse": {
+      "version": "1.0.7",
+      "from": "argparse@>=1.0.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+    },
+    "arr-flatten": {
+      "version": "1.0.1",
+      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-differ": {
       "version": "1.0.0",
@@ -46,6 +113,11 @@
       "version": "1.0.3",
       "from": "array-uniq@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "from": "array-unique@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "asar": {
       "version": "0.11.0",
@@ -69,10 +141,20 @@
       "from": "assert-plus@>=0.1.5 <0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
+    "assertion-error": {
+      "version": "1.0.2",
+      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
+    },
     "async": {
       "version": "1.5.2",
       "from": "async@>=0.1.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+    },
+    "atob": {
+      "version": "1.1.3",
+      "from": "atob@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz"
     },
     "aws-sign2": {
       "version": "0.5.0",
@@ -83,6 +165,11 @@
       "version": "1.4.1",
       "from": "aws4@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
+    },
+    "babel-runtime": {
+      "version": "5.8.38",
+      "from": "babel-runtime@>=5.8.25 <6.0.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz"
     },
     "balanced-match": {
       "version": "0.4.1",
@@ -134,6 +221,11 @@
       "from": "brace-expansion@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
     },
+    "braces": {
+      "version": "1.8.5",
+      "from": "braces@>=1.8.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+    },
     "buffer": {
       "version": "3.6.0",
       "from": "buffer@>=3.0.1 <4.0.0",
@@ -155,6 +247,28 @@
       "version": "1.0.0",
       "from": "buffer-shims@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+    },
+    "buffer-to-vinyl": {
+      "version": "1.1.0",
+      "from": "buffer-to-vinyl@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        },
+        "vinyl": {
+          "version": "1.1.1",
+          "from": "vinyl@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+        }
+      }
     },
     "buffers": {
       "version": "0.1.1",
@@ -193,6 +307,11 @@
       "from": "caseless@>=0.9.0 <0.10.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
     },
+    "center-align": {
+      "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+    },
     "chainsaw": {
       "version": "0.1.0",
       "from": "chainsaw@>=0.1.0 <0.2.0",
@@ -207,6 +326,11 @@
       "version": "0.1.0",
       "from": "chromium-pickle-js@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz"
+    },
+    "cli-width": {
+      "version": "1.1.1",
+      "from": "cli-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
     },
     "cliui": {
       "version": "3.2.0",
@@ -223,6 +347,11 @@
       "from": "clone-stats@>=0.0.1 <0.0.2",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
+    "co": {
+      "version": "4.6.0",
+      "from": "co@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+    },
     "code-point-at": {
       "version": "1.0.0",
       "from": "code-point-at@>=1.0.0 <2.0.0",
@@ -237,6 +366,11 @@
       "version": "2.9.0",
       "from": "commander@>=2.9.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+    },
+    "compress-commons": {
+      "version": "0.2.9",
+      "from": "compress-commons@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
@@ -260,10 +394,25 @@
         }
       }
     },
+    "convert-source-map": {
+      "version": "1.2.0",
+      "from": "convert-source-map@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
+    },
+    "core-js": {
+      "version": "1.2.6",
+      "from": "core-js@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+    },
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "crc32-stream": {
+      "version": "0.3.4",
+      "from": "crc32-stream@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz"
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -279,6 +428,28 @@
       "version": "3.1.6",
       "from": "crypto-js@>=3.1.4 <4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.6.tgz"
+    },
+    "css": {
+      "version": "2.2.1",
+      "from": "css@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.38 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
+        }
+      }
+    },
+    "css-parse": {
+      "version": "2.0.0",
+      "from": "css-parse@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz"
+    },
+    "css-value": {
+      "version": "0.0.1",
+      "from": "css-value@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz"
     },
     "ctype": {
       "version": "0.5.3",
@@ -371,10 +542,32 @@
         }
       }
     },
+    "deep-eql": {
+      "version": "0.1.3",
+      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "from": "type-detect@0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+        }
+      }
+    },
     "deep-extend": {
       "version": "0.4.1",
       "from": "deep-extend@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "from": "deep-is@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+    },
+    "deepmerge": {
+      "version": "0.2.10",
+      "from": "deepmerge@>=0.2.7 <0.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.10.tgz"
     },
     "defaults": {
       "version": "1.0.3",
@@ -386,10 +579,25 @@
       "from": "delayed-stream@0.0.5",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
     },
+    "depd": {
+      "version": "1.1.0",
+      "from": "depd@1.1.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+    },
     "deprecated": {
       "version": "0.0.1",
       "from": "deprecated@>=0.0.1 <0.0.2",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
+    },
+    "dev-null": {
+      "version": "0.1.1",
+      "from": "dev-null@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz"
+    },
+    "diff": {
+      "version": "1.4.0",
+      "from": "diff@1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
     },
     "duplexer": {
       "version": "0.1.1",
@@ -413,6 +621,28 @@
       "from": "duplexer3@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz"
     },
+    "duplexify": {
+      "version": "3.4.3",
+      "from": "duplexify@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.0.0",
+          "from": "end-of-stream@1.0.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        }
+      }
+    },
     "each-async": {
       "version": "1.1.1",
       "from": "each-async@>=1.0.0 <2.0.0",
@@ -422,6 +652,233 @@
       "version": "0.1.1",
       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+    },
+    "ejs": {
+      "version": "2.4.2",
+      "from": "ejs@>=2.3.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.4.2.tgz"
+    },
+    "electron-chromedriver": {
+      "version": "1.2.0",
+      "from": "electron-chromedriver@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-1.2.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "from": "assert-plus@^0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@~0.6.0",
+          "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+        },
+        "bl": {
+          "version": "1.1.2",
+          "from": "bl@~1.1.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "from": "readable-stream@~2.0.5",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+            }
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "from": "caseless@~0.11.0",
+          "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+        },
+        "clone": {
+          "version": "0.2.0",
+          "from": "clone@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@~1.0.5",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+        },
+        "decompress": {
+          "version": "3.0.0",
+          "from": "decompress@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz"
+        },
+        "decompress-tar": {
+          "version": "3.1.0",
+          "from": "decompress-tar@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz"
+        },
+        "decompress-tarbz2": {
+          "version": "3.1.0",
+          "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz"
+        },
+        "decompress-targz": {
+          "version": "3.1.0",
+          "from": "decompress-targz@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz"
+        },
+        "decompress-unzip": {
+          "version": "3.4.0",
+          "from": "decompress-unzip@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "from": "clone@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+            },
+            "readable-stream": {
+              "version": "2.0.6",
+              "from": "readable-stream@~2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+            },
+            "through2": {
+              "version": "2.0.1",
+              "from": "through2@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "1.1.1",
+              "from": "vinyl@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "delayed-stream@~1.0.0",
+          "resolved": "http://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "form-data": {
+          "version": "1.0.0-rc4",
+          "from": "form-data@~1.0.0-rc3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+        },
+        "glob-stream": {
+          "version": "5.3.2",
+          "from": "glob-stream@>=5.3.2 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.2.tgz"
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "from": "har-validator@~2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@~3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@~1.1.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "mime-db": {
+          "version": "1.23.0",
+          "from": "mime-db@~1.23.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "from": "mime-types@~2.1.7",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@~0.8.1",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "ordered-read-streams": {
+          "version": "0.3.0",
+          "from": "ordered-read-streams@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.1.4",
+              "from": "readable-stream@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "6.1.0",
+          "from": "qs@~6.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
+        },
+        "request": {
+          "version": "2.72.0",
+          "from": "request@^2.65.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+        },
+        "unique-stream": {
+          "version": "2.2.1",
+          "from": "unique-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@>=0.4.3 <0.5.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+        },
+        "vinyl-fs": {
+          "version": "2.4.3",
+          "from": "vinyl-fs@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "from": "clone@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "from": "object-assign@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+            },
+            "readable-stream": {
+              "version": "2.1.4",
+              "from": "readable-stream@>=2.0.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+            },
+            "through2": {
+              "version": "2.0.1",
+              "from": "through2@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "from": "readable-stream@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "1.1.1",
+              "from": "vinyl@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+            }
+          }
+        }
+      }
     },
     "electron-download": {
       "version": "2.1.2",
@@ -455,15 +912,62 @@
       "from": "escape-string-regexp@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
+    "escodegen": {
+      "version": "1.7.1",
+      "from": "escodegen@>=1.7.0 <1.8.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.5",
+          "from": "esprima@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+        }
+      }
+    },
+    "esprima": {
+      "version": "2.5.0",
+      "from": "esprima@>=2.5.0 <2.6.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz"
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "from": "estraverse@>=1.9.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "from": "esutils@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+    },
     "event-stream": {
       "version": "3.1.7",
       "from": "event-stream@>=3.1.0 <3.2.0",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz"
     },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "from": "expand-range@>=1.8.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
+    },
     "extend": {
       "version": "3.0.0",
       "from": "extend@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "from": "extend-shallow@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "from": "extglob@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extract-zip": {
       "version": "1.5.0",
@@ -497,15 +1001,47 @@
       "from": "fancy-log@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz"
     },
+    "fast-levenshtein": {
+      "version": "1.0.7",
+      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+    },
     "fd-slicer": {
       "version": "1.0.1",
       "from": "fd-slicer@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
+    "figures": {
+      "version": "1.7.0",
+      "from": "figures@>=1.3.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
+    },
     "file-type": {
       "version": "3.8.0",
       "from": "file-type@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.8.0.tgz"
+    },
+    "filename-regex": {
+      "version": "2.0.0",
+      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+    },
+    "fileset": {
+      "version": "0.2.1",
+      "from": "fileset@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        }
+      }
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "from": "fill-range@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "find-index": {
       "version": "0.1.1",
@@ -531,6 +1067,16 @@
       "version": "0.3.2",
       "from": "flagged-respawn@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
+    },
+    "for-in": {
+      "version": "0.1.5",
+      "from": "for-in@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
+    },
+    "for-own": {
+      "version": "0.1.4",
+      "from": "for-own@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -610,6 +1156,16 @@
       "version": "5.0.15",
       "from": "glob@>=5.0.3 <6.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "from": "glob-base@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "from": "glob-parent@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "glob-stream": {
       "version": "3.1.18",
@@ -707,6 +1263,38 @@
       "from": "graceful-readlink@>=1.0.0",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
+    "growl": {
+      "version": "1.9.2",
+      "from": "growl@1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
+    },
+    "gulp-sourcemaps": {
+      "version": "1.6.0",
+      "from": "gulp-sourcemaps@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "from": "readable-stream@~2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        },
+        "through2": {
+          "version": "2.0.1",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        },
+        "vinyl": {
+          "version": "1.1.1",
+          "from": "vinyl@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.1.tgz"
+        }
+      }
+    },
     "gulp-util": {
       "version": "3.0.7",
       "from": "gulp-util@>=3.0.0 <4.0.0",
@@ -739,6 +1327,18 @@
       "from": "gulplog@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
+    "handlebars": {
+      "version": "4.0.5",
+      "from": "handlebars@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.4 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
+    },
     "har-validator": {
       "version": "1.8.0",
       "from": "har-validator@>=1.4.0 <2.0.0",
@@ -755,6 +1355,11 @@
       "version": "2.0.0",
       "from": "has-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "from": "has-flag@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
@@ -816,6 +1421,18 @@
       "from": "ini@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
+    "inquirer": {
+      "version": "0.8.5",
+      "from": "inquirer@>=0.8.5 <0.9.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "from": "ansi-regex@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+        }
+      }
+    },
     "interpret": {
       "version": "1.0.1",
       "from": "interpret@>=1.0.0 <2.0.0",
@@ -836,10 +1453,40 @@
       "from": "is-arrayish@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
+    "is-buffer": {
+      "version": "1.1.3",
+      "from": "is-buffer@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+    },
     "is-builtin-module": {
       "version": "1.0.0",
       "from": "is-builtin-module@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+    },
+    "is-bzip2": {
+      "version": "1.0.0",
+      "from": "is-bzip2@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+    },
+    "is-dotfile": {
+      "version": "1.0.2",
+      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "from": "is-extendable@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
@@ -851,6 +1498,21 @@
       "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
+    "is-generator": {
+      "version": "1.0.3",
+      "from": "is-generator@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz"
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "from": "is-glob@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+    },
+    "is-gzip": {
+      "version": "1.0.0",
+      "from": "is-gzip@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+    },
     "is-my-json-valid": {
       "version": "2.13.1",
       "from": "is-my-json-valid@>=2.12.0 <3.0.0",
@@ -860,6 +1522,11 @@
       "version": "2.1.1",
       "from": "is-natural-number@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz"
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "from": "is-number@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -880,6 +1547,16 @@
       "version": "1.1.0",
       "from": "is-plain-obj@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
@@ -906,6 +1583,11 @@
       "from": "is-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
+    "is-tar": {
+      "version": "1.0.0",
+      "from": "is-tar@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
@@ -916,25 +1598,93 @@
       "from": "is-utf8@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
+    "is-valid-glob": {
+      "version": "0.3.0",
+      "from": "is-valid-glob@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz"
+    },
+    "is-zip": {
+      "version": "1.0.0",
+      "from": "is-zip@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+    },
     "isarray": {
       "version": "0.0.1",
       "from": "isarray@0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+    },
+    "isexe": {
+      "version": "1.1.2",
+      "from": "isexe@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "from": "isobject@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
       "from": "isstream@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
+    "istanbul": {
+      "version": "0.3.22",
+      "from": "istanbul@>=0.3.5 <0.4.0",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
+      "dependencies": {
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        }
+      }
+    },
     "istextorbinary": {
       "version": "1.0.2",
       "from": "istextorbinary@1.0.2",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz"
     },
+    "jade": {
+      "version": "0.26.3",
+      "from": "jade@0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "from": "commander@0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "from": "mkdirp@0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+        }
+      }
+    },
     "jodid25519": {
       "version": "1.0.2",
       "from": "jodid25519@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+    },
+    "js-yaml": {
+      "version": "3.6.1",
+      "from": "js-yaml@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2",
+          "from": "esprima@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+        }
+      }
     },
     "jsbn": {
       "version": "0.1.0",
@@ -946,6 +1696,11 @@
       "from": "json-schema@0.2.2",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "from": "json-stringify-safe@>=5.0.0 <5.1.0",
@@ -955,6 +1710,11 @@
       "version": "2.3.1",
       "from": "jsonfile@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "from": "jsonify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
@@ -966,15 +1726,47 @@
       "from": "jsprim@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
     },
+    "kind-of": {
+      "version": "3.0.3",
+      "from": "kind-of@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz"
+    },
     "klaw": {
       "version": "1.3.0",
       "from": "klaw@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
     },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "from": "lazystream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        }
+      }
+    },
     "lcid": {
       "version": "1.0.0",
       "from": "lcid@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+    },
+    "levn": {
+      "version": "0.2.5",
+      "from": "levn@>=0.2.5 <0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
     },
     "liftoff": {
       "version": "2.2.4",
@@ -1006,15 +1798,40 @@
       "from": "lodash._basevalues@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
+    "lodash._escapehtmlchar": {
+      "version": "2.4.1",
+      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz"
+    },
+    "lodash._escapestringchar": {
+      "version": "2.4.1",
+      "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+    },
     "lodash._getnative": {
       "version": "3.9.1",
       "from": "lodash._getnative@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
+    "lodash._htmlescapes": {
+      "version": "2.4.1",
+      "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+    },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+    },
+    "lodash._isnative": {
+      "version": "2.4.1",
+      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+    },
+    "lodash._objecttypes": {
+      "version": "2.4.1",
+      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
     },
     "lodash._reescape": {
       "version": "3.0.0",
@@ -1031,10 +1848,27 @@
       "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
+    "lodash._reunescapedhtml": {
+      "version": "2.4.1",
+      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "from": "lodash.keys@~2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+        }
+      }
+    },
     "lodash._root": {
       "version": "3.0.1",
       "from": "lodash._root@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+    },
+    "lodash._shimkeys": {
+      "version": "2.4.1",
+      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
     },
     "lodash._stringtopath": {
       "version": "4.8.0",
@@ -1045,6 +1879,18 @@
       "version": "4.0.9",
       "from": "lodash.assign@>=4.0.3 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz"
+    },
+    "lodash.defaults": {
+      "version": "2.4.1",
+      "from": "lodash.defaults@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "from": "lodash.keys@~2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+        }
+      }
     },
     "lodash.escape": {
       "version": "3.2.0",
@@ -1065,6 +1911,16 @@
       "version": "3.0.4",
       "from": "lodash.isarray@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+    },
+    "lodash.isequal": {
+      "version": "4.2.0",
+      "from": "lodash.isequal@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.2.0.tgz"
+    },
+    "lodash.isobject": {
+      "version": "2.4.1",
+      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
     },
     "lodash.keys": {
       "version": "4.0.7",
@@ -1103,6 +1959,18 @@
       "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
     },
+    "lodash.values": {
+      "version": "2.4.1",
+      "from": "lodash.values@>=2.4.1 <2.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "from": "lodash.keys@~2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+        }
+      }
+    },
     "log-rotate": {
       "version": "0.2.7",
       "from": "log-rotate@>=0.2.7 <0.3.0",
@@ -1119,6 +1987,16 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
+    },
+    "lokijs": {
+      "version": "1.4.1",
+      "from": "lokijs@latest",
+      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.4.1.tgz"
+    },
+    "longest": {
+      "version": "1.0.1",
+      "from": "longest@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loud-rejection": {
       "version": "1.5.0",
@@ -1154,6 +2032,38 @@
       "version": "3.7.0",
       "from": "meow@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+    },
+    "merge": {
+      "version": "1.2.0",
+      "from": "merge@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+    },
+    "merge-stream": {
+      "version": "1.0.0",
+      "from": "merge-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        }
+      }
+    },
+    "micromatch": {
+      "version": "2.3.10",
+      "from": "micromatch@>=2.3.7 <3.0.0",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.10.tgz"
+    },
+    "mime": {
+      "version": "1.2.11",
+      "from": "mime@>=1.2.11 <1.3.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
     },
     "mime-db": {
       "version": "1.12.0",
@@ -1209,6 +2119,38 @@
         }
       }
     },
+    "mocha": {
+      "version": "2.5.3",
+      "from": "mocha@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "from": "commander@2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "from": "escape-string-regexp@1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "from": "supports-color@1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
+        }
+      }
+    },
     "ms": {
       "version": "0.7.1",
       "from": "ms@0.7.1",
@@ -1218,6 +2160,11 @@
       "version": "0.1.2",
       "from": "multipipe@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
+    },
+    "mute-stream": {
+      "version": "0.0.4",
+      "from": "mute-stream@0.0.4",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
     },
     "mv": {
       "version": "2.1.1",
@@ -1241,6 +2188,11 @@
       "from": "ncp@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
     },
+    "node-int64": {
+      "version": "0.3.3",
+      "from": "node-int64@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz"
+    },
     "node-status-codes": {
       "version": "2.0.0",
       "from": "node-status-codes@>=2.0.0 <3.0.0",
@@ -1251,6 +2203,11 @@
       "from": "node-uuid@>=1.4.0 <1.5.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
+    "noop2": {
+      "version": "2.0.0",
+      "from": "noop2@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/noop2/-/noop2-2.0.0.tgz"
+    },
     "nopt": {
       "version": "3.0.6",
       "from": "nopt@>=3.0.1 <4.0.0",
@@ -1260,6 +2217,16 @@
       "version": "2.3.5",
       "from": "normalize-package-data@>=2.3.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+    },
+    "normalize-path": {
+      "version": "2.0.1",
+      "from": "normalize-path@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+    },
+    "npm-install-package": {
+      "version": "1.0.2",
+      "from": "npm-install-package@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-1.0.2.tgz"
     },
     "nugget": {
       "version": "1.6.2",
@@ -1291,6 +2258,11 @@
       "from": "object-keys@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
     },
+    "object.omit": {
+      "version": "2.0.0",
+      "from": "object.omit@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
+    },
     "once": {
       "version": "1.3.3",
       "from": "once@>=1.3.0 <2.0.0",
@@ -1300,6 +2272,35 @@
       "version": "1.1.0",
       "from": "onetime@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "from": "optimist@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "from": "minimist@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.5.0",
+      "from": "optionator@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        }
+      }
     },
     "orchestrator": {
       "version": "0.3.7",
@@ -1325,6 +2326,16 @@
       "version": "1.0.6",
       "from": "os-timesync@>=1.0.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-timesync/-/os-timesync-1.0.6.tgz"
+    },
+    "os-tmpdir": {
+      "version": "1.0.1",
+      "from": "os-tmpdir@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
@@ -1386,10 +2397,20 @@
       "from": "plist@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz"
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "from": "prelude-ls@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+    },
     "prepend-http": {
       "version": "1.0.4",
       "from": "prepend-http@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "from": "preserve@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-bytes": {
       "version": "1.0.4",
@@ -1411,6 +2432,11 @@
       "from": "progress-stream@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz"
     },
+    "punycode": {
+      "version": "1.3.2",
+      "from": "punycode@1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+    },
     "q": {
       "version": "1.4.1",
       "from": "q@>=1.1.2 <2.0.0",
@@ -1421,10 +2447,37 @@
       "from": "qs@>=2.4.0 <2.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
     },
+    "querystring": {
+      "version": "0.2.0",
+      "from": "querystring@0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+    },
+    "randomatic": {
+      "version": "1.1.5",
+      "from": "randomatic@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+    },
     "rc": {
       "version": "1.1.6",
       "from": "rc@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz"
+    },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "from": "read-all-stream@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        }
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -1441,6 +2494,23 @@
       "from": "readable-stream@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
     },
+    "readline2": {
+      "version": "0.1.1",
+      "from": "readline2@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "from": "ansi-regex@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+        }
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "from": "rechoir@>=0.6.2 <0.7.0",
@@ -1450,6 +2520,21 @@
       "version": "1.0.0",
       "from": "redent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
+    },
+    "regex-cache": {
+      "version": "0.4.3",
+      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+    },
+    "repeat-string": {
+      "version": "1.5.4",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
     },
     "repeating": {
       "version": "2.0.1",
@@ -1515,6 +2600,21 @@
       "from": "resolve@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "from": "resolve-url@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
+    },
+    "rgb2hex": {
+      "version": "0.1.0",
+      "from": "rgb2hex@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "from": "right-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+    },
     "rimraf": {
       "version": "2.5.2",
       "from": "rimraf@>=2.2.8 <3.0.0",
@@ -1531,6 +2631,11 @@
       "version": "1.1.4",
       "from": "run-series@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz"
+    },
+    "rx": {
+      "version": "2.5.3",
+      "from": "rx@>=2.4.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
     },
     "seek-bzip": {
       "version": "1.0.5",
@@ -1589,6 +2694,21 @@
       "from": "solc@>=0.3.1-1 <0.4.0",
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.3.5.tgz"
     },
+    "source-map": {
+      "version": "0.2.0",
+      "from": "source-map@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+    },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "from": "source-map-resolve@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz"
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "from": "source-map-url@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+    },
     "sparkles": {
       "version": "1.0.0",
       "from": "sparkles@>=1.0.0 <2.0.0",
@@ -1624,6 +2744,11 @@
       "from": "split@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "from": "sprintf-js@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+    },
     "sshpk": {
       "version": "1.8.3",
       "from": "sshpk@>=1.7.0 <2.0.0",
@@ -1641,10 +2766,37 @@
         }
       }
     },
+    "stat-mode": {
+      "version": "0.2.1",
+      "from": "stat-mode@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
+    },
     "stream-combiner": {
       "version": "0.0.4",
       "from": "stream-combiner@>=0.0.4 <0.1.0",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "from": "stream-combiner2@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.1.4",
+          "from": "duplexer2@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        }
+      }
     },
     "stream-consume": {
       "version": "0.1.0",
@@ -1675,6 +2827,11 @@
       "version": "2.0.0",
       "from": "strip-bom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+    },
+    "strip-bom-stream": {
+      "version": "1.0.0",
+      "from": "strip-bom-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz"
     },
     "strip-dirs": {
       "version": "1.1.1",
@@ -1772,6 +2929,28 @@
         }
       }
     },
+    "through2-filter": {
+      "version": "2.0.0",
+      "from": "through2-filter@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "from": "readable-stream@~2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        },
+        "through2": {
+          "version": "2.0.1",
+          "from": "through2@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        }
+      }
+    },
     "tildify": {
       "version": "1.2.0",
       "from": "tildify@>=1.0.0 <2.0.0",
@@ -1786,6 +2965,21 @@
       "version": "2.0.0",
       "from": "timed-out@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+    },
+    "tmp": {
+      "version": "0.0.28",
+      "from": "tmp@0.0.28",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz"
+    },
+    "to-absolute-glob": {
+      "version": "0.1.1",
+      "from": "to-absolute-glob@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz"
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "from": "to-iso-string@0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
     },
     "touch": {
       "version": "0.0.3",
@@ -1824,10 +3018,67 @@
       "from": "tweetnacl@>=0.13.0 <0.14.0",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
+    "type-check": {
+      "version": "0.3.2",
+      "from": "type-check@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "from": "type-detect@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+    },
     "typedarray": {
       "version": "0.0.6",
       "from": "typedarray@>=0.0.5 <0.1.0",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+    },
+    "uglify-js": {
+      "version": "2.6.4",
+      "from": "uglify-js@>=2.6.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "from": "camelcase@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "from": "cliui@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "from": "window-size@0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "from": "yargs@>=3.10.0 <3.11.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "unbzip2-stream": {
       "version": "1.0.9",
@@ -1848,6 +3099,16 @@
       "version": "1.0.0",
       "from": "unzip-response@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
+    },
+    "urix": {
+      "version": "0.1.0",
+      "from": "urix@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+    },
+    "url": {
+      "version": "0.10.3",
+      "from": "url@>=0.10.3 <0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz"
     },
     "url-parse-lax": {
       "version": "1.0.0",
@@ -1879,10 +3140,20 @@
       "from": "v8flags@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
     },
+    "vali-date": {
+      "version": "1.0.0",
+      "from": "vali-date@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz"
+    },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+    },
+    "validator": {
+      "version": "4.9.0",
+      "from": "validator@>=4.5.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz"
     },
     "verror": {
       "version": "1.3.6",
@@ -1893,6 +3164,23 @@
       "version": "0.5.3",
       "from": "vinyl@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+    },
+    "vinyl-assign": {
+      "version": "1.2.1",
+      "from": "vinyl-assign@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@~1.0.0",
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        }
+      }
     },
     "vinyl-fs": {
       "version": "0.3.14",
@@ -1926,6 +3214,11 @@
         }
       }
     },
+    "wdio-dot-reporter": {
+      "version": "0.0.4",
+      "from": "wdio-dot-reporter@0.0.4",
+      "resolved": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.4.tgz"
+    },
     "web3": {
       "version": "0.17.0-alpha",
       "from": "web3@>=0.17.0-alpha <0.18.0",
@@ -1938,10 +3231,107 @@
         }
       }
     },
+    "webdriverio": {
+      "version": "4.1.1",
+      "from": "webdriverio@>=4.0.4 <5.0.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.1.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "boom": {
+          "version": "0.4.2",
+          "from": "boom@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+        },
+        "caseless": {
+          "version": "0.8.0",
+          "from": "caseless@>=0.8.0 <0.9.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+        },
+        "cryptiles": {
+          "version": "0.2.2",
+          "from": "cryptiles@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "from": "forever-agent@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+        },
+        "form-data": {
+          "version": "0.1.4",
+          "from": "form-data@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz"
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "from": "hawk@1.1.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz"
+        },
+        "hoek": {
+          "version": "0.9.1",
+          "from": "hoek@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "from": "mime-types@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.5.0",
+          "from": "oauth-sign@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+        },
+        "q": {
+          "version": "1.3.0",
+          "from": "q@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.3.0.tgz"
+        },
+        "qs": {
+          "version": "2.3.3",
+          "from": "qs@>=2.3.1 <2.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+        },
+        "request": {
+          "version": "2.49.0",
+          "from": "request@2.49.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.49.0.tgz"
+        },
+        "sntp": {
+          "version": "0.2.4",
+          "from": "sntp@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+        },
+        "supports-color": {
+          "version": "1.3.1",
+          "from": "supports-color@>=1.3.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+        }
+      }
+    },
+    "wgxpath": {
+      "version": "1.0.0",
+      "from": "wgxpath@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz"
+    },
+    "which": {
+      "version": "1.2.10",
+      "from": "which@>=1.2.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
+    },
     "window-size": {
       "version": "0.2.0",
       "from": "window-size@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "from": "wordwrap@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
     },
     "wrap-ansi": {
       "version": "2.0.0",
@@ -1999,6 +3389,23 @@
       "version": "2.4.1",
       "from": "yauzl@2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
+    },
+    "yazl": {
+      "version": "2.4.0",
+      "from": "yazl@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.0.tgz"
+    },
+    "zip-stream": {
+      "version": "0.5.2",
+      "from": "zip-stream@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "3.2.0",
+          "from": "lodash@>=3.2.0 <3.3.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "i18next": "^2.3.4",
     "log-rotate": "^0.2.7",
     "log4js": "^0.6.35",
+    "lokijs": "^1.4.1",
     "minimongo-standalone": "0.0.9",
     "numeral": "^1.5.3",
     "os-timesync": "^1.0.6",


### PR DESCRIPTION
This refactors the Minimongo front-to-back synchronization so that we can store the user's Mist tabs in the file system instead of browser `localStorage`.

* Flexible, so that we can still store some stuff in `localStorage`.
* Uses [LokiJS](lokijs.org) for file system storage.

