### PR TITLE
Make app name in browserBar dynamic and improve wording

### DIFF
--- a/interface/client/templates/layout/browserBar_accounts.html
+++ b/interface/client/templates/layout/browserBar_accounts.html
@@ -1,7 +1,7 @@
 <template name="layout_browserBar_accounts">
     <div class="message">
-        <h3> <em>Wallet</em> wants to know one or more of your public accounts</h3>
-        <p>Sharing an identity would allow this dapp have access to all your public information, including public balance, but <strong>will not allow </strong>  the dapp to publish anything, move funds or send transactions under your name.
+        <h3><em>{{appName}}</em> wants to know one or more of your public accounts</h3>
+        <p>Sharing an identity gives this dapp access to all your public information, including public balance, but <strong>will not allow </strong> the dapp to publish anything, move funds or send transactions under your name.
         </p>
         <p>You can select more than one account.</p>             
     </div>

--- a/interface/client/templates/layout/browserBar_accounts.js
+++ b/interface/client/templates/layout/browserBar_accounts.js
@@ -62,6 +62,17 @@ Template['layout_browserBar_accounts'].helpers({
         // return (tab &&
         //     tab.permissions &&
         //     tab.permissions.accounts) ? tab.permissions.accounts.length : 0;
+    },
+    /**
+    Return the name of the current tab.
+
+    @method appName
+    @return {String}
+    */
+    'appName': function(){
+        var tabId = LocalStore.get('selectedTab'),
+            tab = Tabs.findOne(tabId);
+        return tab.name || 'This app';
     }
 });
 


### PR DESCRIPTION
The browser bar currently always displays "Wallet" for all apps. I changed it to make it dynamic based on the current tab.