### PR TITLE
rename 'passwordError' to 'wrongPassword' for consistency

### DIFF
--- a/interface/client/templates/popupWindows/onboardingScreen.js
+++ b/interface/client/templates/popupWindows/onboardingScreen.js
@@ -295,7 +295,7 @@ Template['popupWindows_onboardingScreen_importAccount'].events({
 
                 if(error === 'Decryption Failed') {
                     GlobalNotification.warning({
-                        content: TAPi18n.__('mist.popupWindows.onboarding.errors.passwordError'),
+                        content: TAPi18n.__('mist.popupWindows.onboarding.errors.wrongPassword'),
                         duration: 4
                     });
                 } else {

--- a/interface/i18n/mist.de.i18n.json
+++ b/interface/i18n/mist.de.i18n.json
@@ -184,7 +184,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Warten Sie noch einige Sekunden, bis der Node gestartet ist, und versuchen Sie es dann noch einmal",
                     "unknownFile": "Datei nicht erkannt.",
-                    "passwordError": "Falsches Passwort.",
+                    "wrongPassword": "Falsches Passwort.",
                     "importFailed": "Beim Import der Datei ist folgender Fehler aufgetreten: __error__"
                 }
             }

--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -228,7 +228,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Wait a few more seconds until your node is fully started and try again",
                     "unknownFile": "File not recognised.",
-                    "passwordError": "Wrong password.",
+                    "wrongPassword": "Wrong password.",
                     "importFailed": "Couldn't import the file, got: __error__"
                 }
             }

--- a/interface/i18n/mist.es.i18n.json
+++ b/interface/i18n/mist.es.i18n.json
@@ -184,7 +184,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Espere unos segundos más hasta que su nodo esté completamente iniciado y vuelva a intentarlo",
                     "unknownFile": "Archivo no reconocido.",
-                    "passwordError": "Contraseña incorrecta.",
+                    "wrongPassword": "Contraseña incorrecta.",
                     "importFailed": "No se pudo importar el archivo por el error: __error__"
                 }
             }

--- a/interface/i18n/mist.fr.i18n.json
+++ b/interface/i18n/mist.fr.i18n.json
@@ -182,7 +182,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Attendez quelques secondes de plus avant que votre nœud soit initialisé et essayez de nouveau",
                     "unknownFile": "Fichier non reconnu.",
-                    "passwordError": "Mauvais mot de passe.",
+                    "wrongPassword": "Mauvais mot de passe.",
                     "importFailed": "Echec à l'importation du fichier avec l'erreur : __error__"
                 }
             }

--- a/interface/i18n/mist.it.i18n.json
+++ b/interface/i18n/mist.it.i18n.json
@@ -184,7 +184,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Attendi qualche secondo ancora finché il tuo nodo non é completamente avviato e riprova",
                     "unknownFile": "File non riconosciuto.",
-                    "passwordError": "Password errata.",
+                    "wrongPassword": "Password errata.",
                     "importFailed": "Impossibile importare il file: __error__"
                 }
             }

--- a/interface/i18n/mist.ja.i18n.json
+++ b/interface/i18n/mist.ja.i18n.json
@@ -182,7 +182,7 @@
                 "errors": {
                     "nodeNotStartedYet": "ノードが開始して再度起動する迄もう少し待つ",
                     "unknownFile": "ファイルが認識できませんでした.",
-                    "passwordError": "passwordが間違っています",
+                    "wrongPassword": "passwordが間違っています",
                     "importFailed": "ファイルが読み込めませんでした: __error__のエラーです"
                 }
             }

--- a/interface/i18n/mist.ko.i18n.json
+++ b/interface/i18n/mist.ko.i18n.json
@@ -184,7 +184,7 @@
                 "errors": {
                     "nodeNotStartedYet": "노드가 완전히 구동될 때까지 몇초 기다렸다 다시 시도해 보세요.",
                     "unknownFile": "파일을 인식할 수 없습니다.",
-                    "passwordError": "암호가 틀렸습니다.",
+                    "wrongPassword": "암호가 틀렸습니다.",
                     "importFailed": "파일을 가져올 수 없습니다: __error__"
                 }
             }

--- a/interface/i18n/mist.kr.i18n.json
+++ b/interface/i18n/mist.kr.i18n.json
@@ -179,7 +179,7 @@
                 "errors": {
                     "nodeNotStartedYet": "노드가 완전히 구동될 때까지 몇초 기다렸다 다시 시도해 보세요.",
                     "unknownFile": "파일을 인식할 수 없습니다.",
-                    "passwordError": "암호가 틀렸습니다.",
+                    "wrongPassword": "암호가 틀렸습니다.",
                     "importFailed": "파일을 가져올 수 없습니다: __error__"
                 }
             }

--- a/interface/i18n/mist.nb.i18n.json
+++ b/interface/i18n/mist.nb.i18n.json
@@ -201,7 +201,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Vent noen sekunder til noden er fullt i gang og prøv igjen",
                     "unknownFile": "Fil ikke gjenkjent.",
-                    "passwordError": "Feil passord.",
+                    "wrongPassword": "Feil passord.",
                     "importFailed": "Kunne ikke importere filen, fikk: __error__"
                 }
             }

--- a/interface/i18n/mist.nl.i18n.json
+++ b/interface/i18n/mist.nl.i18n.json
@@ -183,7 +183,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Wacht nog een aantal seconden tot uw node volledig is opgestart en probeer het nog een keer",
                     "unknownFile": "Bestand niet herkent.",
-                    "passwordError": "Incorrect wachtwoord.",
+                    "wrongPassword": "Incorrect wachtwoord.",
                     "importFailed": "Kon bestand niet inporteren en kreeg: __error__"
                 }
             }

--- a/interface/i18n/mist.pt.i18n.json
+++ b/interface/i18n/mist.pt.i18n.json
@@ -186,7 +186,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Espere alguns segundos e tente novamente",
                     "unknownFile": "Arquivo não reconhecido.",
-                    "passwordError": "Senha incorreta.",
+                    "wrongPassword": "Senha incorreta.",
                     "importFailed": "Não pode importar. Erro: __error__"
                 }
             }

--- a/interface/i18n/mist.sq.i18n.json
+++ b/interface/i18n/mist.sq.i18n.json
@@ -178,7 +178,7 @@
                 "errors": {
                     "nodeNotStartedYet": "Wait a few more seconds until your node is fully started and try again",
                     "unknownFile": "File not recognised.",
-                    "passwordError": "Wrong password.",
+                    "wrongPassword": "Wrong password.",
                     "importFailed": "Couldn't import the file got: __error__"
                 }
             }

--- a/interface/i18n/mist.zh-TW.i18n.json
+++ b/interface/i18n/mist.zh-TW.i18n.json
@@ -185,7 +185,7 @@
                 "errors": {
                     "nodeNotStartedYet": "請等待片刻直到您的節點完全啓動再重新嘗試一次",
                     "unknownFile": "文件無法識別。",
-                    "passwordError": "密碼錯誤。",
+                    "wrongPassword": "密碼錯誤。",
                     "importFailed": "無法匯入該文件，錯誤：__error__"
                 }
             }

--- a/interface/i18n/mist.zh.i18n.json
+++ b/interface/i18n/mist.zh.i18n.json
@@ -184,7 +184,7 @@
                 "errors": {
                     "nodeNotStartedYet": "请等待片刻直到你的节点完全启动再重新尝试一次",
                     "unknownFile": "文件无法识别。",
-                    "passwordError": "密码错误。",
+                    "wrongPassword": "密码错误。",
                     "importFailed": "无法导入该文件，错误：__error__"
                 }
             }


### PR DESCRIPTION
For a consistent naming scheme.

As in [mist.en.i18n.json](https://github.com/luclu/mist/blob/8b9d968dc6017cd9337b51621a0c0a93f8dc57fd/interface/i18n/mist.en.i18n.json), etc:
```javascript
"unlockMasterPassword": {
                "title": "Master-Passwort eingeben",
                "enterPassword": "Geben Sie das Master-Passwort ein",
                "unlocking": "Entschlüsseln...",
                "errors": {
                    "wrongPassword": "Passwort falsch, bitte nochmals versuchen."
}


"errors": {
                    "connectionTimeout": "Eine Verbindung mit dem Node war nicht möglich, eventuell ist der Node im Hintergrund abgestürzt?",
                    "wrongPassword": "Falsches Passwort"
}
```