### PR TITLE
refactor sendTransaction error alerts

### DIFF
--- a/interface/client/templates/popupWindows/sendTransactionConfirmation.js
+++ b/interface/client/templates/popupWindows/sendTransactionConfirmation.js
@@ -215,19 +215,34 @@ Template['popupWindows_sendTransactionConfirmation'].events({
                     template.find('input[type="password"]').value = '';
                     template.$('input[type="password"]').focus();
                 });
-
-                if(e.message.indexOf('CONNECTION ERROR') !== -1) {
+                if(e.message.indexOf('Unable to connect to socket: timeout') !== -1) {
                     GlobalNotification.warning({
                         content: TAPi18n.__('mist.popupWindows.sendTransactionConfirmation.errors.connectionTimeout'),
-                        duration: 3
+                        duration: 5
                     });
-                } else {
+                } else if(e.message.indexOf('could not decrypt key with given passphrase') !== -1) {
                     GlobalNotification.warning({
                         content: TAPi18n.__('mist.popupWindows.sendTransactionConfirmation.errors.wrongPassword'),
                         duration: 3
+                    });
+                } else if(e.message.indexOf('multiple keys match address') !== -1) {
+                    GlobalNotification.warning({
+                        content: TAPi18n.__('mist.popupWindows.sendTransactionConfirmation.errors.multipleKeysMatchAddress'),
+                        duration: 10
+                    });
+                } else if(e.message.indexOf('Insufficient funds for gas * price + value') !== -1) {
+                    GlobalNotification.warning({
+                        content: TAPi18n.__('mist.popupWindows.sendTransactionConfirmation.errors.insufficientFundsForGas'),
+                        duration: 5
+                    });
+                } else {
+                    GlobalNotification.warning({
+                        content: e.message,
+                        duration: 5
                     });
                 }
             }
         });
    } 
 });
+

--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -185,7 +185,9 @@
                 },
                 "errors": {
                     "connectionTimeout": "Couldn't connect to the node, did it crash in the background?",
-                    "wrongPassword": "Wrong password"
+                    "wrongPassword": "Wrong password",
+                    "multipleKeysMatchAddress": "Multiple keys match address, please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas"
                 }
             },
             "onboarding": {


### PR DESCRIPTION
closes https://github.com/ethereum/mist/issues/664
>We will try to catch this error by `string` for now. But to ensure compatibility to other nodes these [error codes](https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal) should be implemented by the nodes.

>Following strings will be emitted by geth:
 - `could not decrypt key with given passphrase` (wrong password)
 - `multiple keys match address` (multiple copies of the same accounts)
 - `Insufficient funds for gas * price + value` (not enough ether in etherbase account to invoke contract transaction)
 - `Unable to connect to socket: timeout` (node terminated, etc; used to be `CONNECTION ERROR`)