### PR TITLE
Put human readable function signatures in the transaction confirmation screen.

### DIFF
--- a/interface/client/templates/popupWindows/sendTransactionConfirmation.html
+++ b/interface/client/templates/popupWindows/sendTransactionConfirmation.html
@@ -27,8 +27,8 @@
                     <div class="amount">
                         {{{totalAmount}}} <span class="unit">ETHER</span>
 
-                        {{#if executionFunction}}
-                            <span class="execute-function">{{executionFunction}}</span>
+                        {{#if TemplateVar.get "executionFunction" }}
+                            <span class="execute-function">{{TemplateVar.get "executionFunction"}}</span>
                         {{/if}}
                     </div>
                     <div>

--- a/modules/preloader/popupWindows.js
+++ b/modules/preloader/popupWindows.js
@@ -9,6 +9,8 @@ require('../openExternal.js');
 const mist = require('../mistAPI.js');
 const ipcProviderWrapper = require('../ipc/ipcProviderWrapper.js');
 const BigNumber = require('bignumber.js');
+const Q = require('bluebird');
+const https = require('https');
 const Web3 = require('web3');
 const web3Admin = require('../web3Admin.js');
 
@@ -29,9 +31,9 @@ ipc.on('data', function(e, data) {
 // make variables globally accessable
 window.mist = mist();
 window.BigNumber = BigNumber;
+window.Q = Q;
 window.web3 = new Web3(new Web3.providers.IpcProvider('', ipcProviderWrapper));
 web3Admin.extend(window.web3);
 
 window.ipc = ipc;
-    
-
+window.https = https;


### PR DESCRIPTION
https://github.com/ethereum/mist/issues/955

### What was wrong

When sending a transaction, the user will be better informed if they are able to see more data about the transaction.

### How was this improved

Now the function signature is queried against the [`4byte.directory`](https://www.4byte.directory/) api to try and lookup the human readable signature.

#### Cute animal picture

![baby-monkeys-in-clothes-wallpaper-3](https://cloud.githubusercontent.com/assets/824194/16783038/9a42affe-483f-11e6-8d11-8e2631d62346.jpg)
