### PR TITLE
disable eth-node switch until hardfork is supported

### DIFF
--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -364,17 +364,8 @@ var menuTempl = function(webviews) {
                 enabled: ethereumNode.isOwnNode,*/
                 enabled: false,
                 type: 'checkbox',
-                /*click: function(){
-                    restartNode('eth');
-                }*/ 
                 click: function(){
-                    Windows.createPopup('about', {
-                        electronOptions: {
-                            width: 420,
-                            height: 230,
-                            alwaysOnTop: true,
-                        }
-                    });
+                    restartNode('eth');
                 }
               }
         ]});

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -359,12 +359,22 @@ var menuTempl = function(webviews) {
                 }
               },
               {
-                label: 'Eth 1.2.9 (C++) [experimental!]',
-                checked: ethereumNode.isOwnNode && ethereumNode.isEth,
-                enabled: ethereumNode.isOwnNode,
+                label: 'Eth 1.2.9 (C++) [no hardfork support!]',
+                /*checked: ethereumNode.isOwnNode && ethereumNode.isEth,
+                enabled: ethereumNode.isOwnNode,*/
+                enabled: false,
                 type: 'checkbox',
-                click: function(){
+                /*click: function(){
                     restartNode('eth');
+                }*/ 
+                click: function(){
+                    Windows.createPopup('about', {
+                        electronOptions: {
+                            width: 420,
+                            height: 230,
+                            alwaysOnTop: true,
+                        }
+                    });
                 }
               }
         ]});


### PR DESCRIPTION
As @bobsummerwill requested - in case eth won't be HF capable until the HF release - this PR disables the menu-entry.
Though eth `1.2.9` will still be bundled.