### PR TITLE
remove 'update-nodes' hook from 'npm install'; add '--platform' option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - "sleep 3" # give xvfb some time to start
   - "curl https://install.meteor.com/ | sh"
-  - "npm install -g electron-prebuilt@1.2.2"
+  - "npm install -g electron-prebuilt@1.2.5"
   - "npm install -g meteor-build-client"
-  - "gulp update-nodes"
+  - "gulp update-nodes --platform linux"
 
 script:
   - "npm run ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
 
 script:
   - "npm run ci"
+  - "gulp update-nodes"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ before_script:
   - "curl https://install.meteor.com/ | sh"
   - "npm install -g electron-prebuilt@1.2.2"
   - "npm install -g meteor-build-client"
+  - "gulp update-nodes"
 
 script:
   - "npm run ci"
-  - "gulp update-nodes"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - "sleep 3" # give xvfb some time to start
   - "curl https://install.meteor.com/ | sh"
-  - "npm install -g electron-prebuilt@1.2.5"
   - "npm install -g meteor-build-client"
   - "gulp update-nodes --platform linux"
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ This will generate the binaries inside the `dist_mist` or `dist_wallet` folder.
 
 Additional you can only build the windows, linux or mac binary by using the `platform` option:
 
+    $ gulp update-nodes --platform darwin
+
+    // And
     $ gulp mist --platform darwin
 
     // Or

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,10 +142,11 @@ gulp.task('downloadNodes', ['clean:nodes'], function(done) {
           //  ? path +'/'+ filenameUppercase +'.app/Contents/Frameworks/node'
             //: path +'/resources/node';
 
-
+            
         // donwload nodes
-        streams.push(download(nodeUrl)
-            .pipe(gulp.dest('./nodes/geth/')));
+        if (os.indexOf(options.platform) !== -1)
+            streams.push(download(nodeUrl)
+                .pipe(gulp.dest('./nodes/geth/')));
 
     });
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "url": "https://github.com/ethereum/mist.git"
   },
   "scripts": {
-    "ci": "gulp --platform=linux",
-    "postinstall": "gulp update-nodes"
+    "ci": "gulp --platform=linux"
   },
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
fixes https://github.com/ethereum/mist/issues/987