### PR TITLE
untrack interface/.meteor/dev_bundle

### DIFF
--- a/interface/.meteor/dev_bundle
+++ b/interface/.meteor/dev_bundle
@@ -1,1 +1,0 @@
-/Users/ram/.meteor/packages/meteor-tool/.1.3.4_4.74t9zv++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle


### PR DESCRIPTION
removes the file from git cache (`git rm --cache ...`),
update on https://github.com/ethereum/mist/pull/977 to remove the annoying git file change