### PR TITLE
fixed #901 , mist now get best matched language code

### DIFF
--- a/modules/i18n.js
+++ b/modules/i18n.js
@@ -17,6 +17,16 @@ i18nConf.supported_languages.forEach(function(lang) {
     resources[lang] = { translation: require('../interface/i18n/mist.'+ lang +'.i18n.json') };
 });
 
+/**
+* Given a language code, get best matched code from supported languages.
+*
+* > getBestMatchedLangCode('en-US')
+* 'en'
+* > getBestMatchedLangCode('zh-TW')
+* 'zh-TW'
+* > getBestMatchedLangCode('no-such-code')
+* 'en'
+*/
 i18n.getBestMatchedLangCode = function(langCode){
     const codeList = Object.keys(resources);
     let bestMatchedCode = langCode;
@@ -24,7 +34,7 @@ i18n.getBestMatchedLangCode = function(langCode){
         if (codeList.indexOf(langCode.substr(0,2)) > -1){
             bestMatchedCode = langCode.substr(0,2);
         }else{
-            bestMatchedCode = 'en'
+            bestMatchedCode = 'en';
         }
     }
     return bestMatchedCode

--- a/modules/i18n.js
+++ b/modules/i18n.js
@@ -17,6 +17,19 @@ i18nConf.supported_languages.forEach(function(lang) {
     resources[lang] = { translation: require('../interface/i18n/mist.'+ lang +'.i18n.json') };
 });
 
+i18n.getBestMatchedLangCode = function(langCode){
+    const codeList = Object.keys(resources);
+    let bestMatchedCode = langCode;
+    if(codeList.indexOf(langCode) === -1){
+        if (codeList.indexOf(langCode.substr(0,2)) > -1){
+            bestMatchedCode = langCode.substr(0,2);
+        }else{
+            bestMatchedCode = 'en'
+        }
+    }
+    return bestMatchedCode
+}
+
 
 // init i18n
 i18n.init({

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -229,6 +229,7 @@ var menuTempl = function(webviews) {
         );
         ipc.emit("backendAction_setLanguage", {}, lang_code);
     }
+    let currentLanguage = i18n.getBestMatchedLangCode(global.language);
 
     let languageMenu =
     Object.keys(i18n.options.resources)
@@ -237,12 +238,12 @@ var menuTempl = function(webviews) {
         menuItem = {
             label: i18n.t('mist.applicationMenu.view.langCodes.' + lang_code),
             type: 'checkbox',
-            checked: (global.language.substr(0,2) === lang_code),
+            checked: (currentLanguage === lang_code),
             click: genSwitchLanguageFunc(lang_code)
         }
         return menuItem
     });
-    let defaultLang = app.getLocale().substr(0,2);    
+    let defaultLang = i18n.getBestMatchedLangCode(app.getLocale());
     languageMenu.unshift({
         label:  i18n.t('mist.applicationMenu.view.default'),
         click: genSwitchLanguageFunc(defaultLang)


### PR DESCRIPTION
hi~
I fixed #901 by adding a `getBestMatchedLangCode` function in i18n module. The mist now get the closest language code from supported language.

Better test this fix with a computer whose default language is `en-US`.