### PR TITLE
fix compile error always defaults to 'e.message.replace is not a function'

### DIFF
--- a/modules/ipc/ipcProviderBackend.js
+++ b/modules/ipc/ipcProviderBackend.js
@@ -337,7 +337,7 @@ class IpcProviderBackend {
 
             if (e.message) {
                 e.error = {
-                    message: e.message.replace(/'[a-z_]*'/i, "'"+ item.method +"'")
+                    message: e.message
                 };
 
                 delete e.message;


### PR DESCRIPTION
fix #1007 