### PR TITLE
Fix for #1007

### DIFF
--- a/interface/.meteor/dev_bundle
+++ b/interface/.meteor/dev_bundle
@@ -1,1 +1,1 @@
-/Users/frozeman/.meteor/packages/meteor-tool/.1.3.4_4.137dnfy++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle
+/Users/ram/.meteor/packages/meteor-tool/.1.3.4_4.74t9zv++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle

--- a/modules/ipc/ipcProviderBackend.js
+++ b/modules/ipc/ipcProviderBackend.js
@@ -340,6 +340,10 @@ class IpcProviderBackend {
             }, error);
 
             if (e.message) {
+                if (_.isArray(e.message)) {
+                    e.message = e.message.pop();
+                }
+                
                 e.error = {
                     message: e.message.replace(/'[a-z_]*'/i, "'"+ item.method +"'")
                 };


### PR DESCRIPTION
This fixes #1007 and sorts out the handling of solidity compiler errors returned.