### PR TITLE
untrack interface/.meteor/dev_bundle (symlink)

### DIFF
--- a/interface/.meteor/dev_bundle
+++ b/interface/.meteor/dev_bundle
@@ -1,1 +1,0 @@
-/Users/frozeman/.meteor/packages/meteor-tool/.1.3.4_4.137dnfy++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle


### PR DESCRIPTION
superseds https://github.com/ethereum/mist/pull/990 which was broken as the symlink's target changed in the meanwhile (meteor internal)

---

>removes the file from git cache (`git rm --cache ...`),
update on #977 to remove the annoying git file change