### PR TITLE
Temporary fix, as per Electron issue #5110

### DIFF
--- a/interface/client/styles/layout.import.less
+++ b/interface/client/styles/layout.import.less
@@ -152,11 +152,11 @@ main {
     &.hidden {
         // visibility: hidden;
         z-index: 1;
-
-        // Temporary fix. See https://github.com/electron/electron/issues/5110
-        height: 0;
-        width: 0;
-        flex: 0 1;
+        webview { 
+            // Temporary fix. See https://github.com/electron/electron/issues/5110
+            height: 0;
+            flex: 0 1;
+        }
     }
 
     &.app-bar-transparent webview {

--- a/interface/client/styles/layout.import.less
+++ b/interface/client/styles/layout.import.less
@@ -150,8 +150,13 @@ main {
     border-top-left-radius: 3px;
 
     &.hidden {
-        visibility: hidden;
+        // visibility: hidden;
         z-index: 1;
+
+        // Temporary fix. See https://github.com/electron/electron/issues/5110
+        height: 0;
+        width: 0;
+        flex: 0 1;
     }
 
     &.app-bar-transparent webview {


### PR DESCRIPTION
When loading a Dapp with transparent appBar, sometimes its ```object``` tag (inside ```webview```) appears cropped, with different heights. It is adjusted back to normal upon window resize.

![screenshot 2016-07-22 17 48 22](https://cloud.githubusercontent.com/assets/47108/17071319/2fc610bc-5037-11e6-89b0-ede40e0b1e68.png)

Digging a bit, and now I can fully reproduce that, it happens when ```ipc.sendToHost('appBar', 'transparent')``` is fired while the referenced Webview is hidden. So Electron can't properly calculate the not visible ```object```'s new size.

I found a temp fix which consists in changing tab's css rules and it seemed to work. I'll follow this issue for future fixes on Electron: https://github.com/electron/electron/issues/5110