### PR TITLE
Fixed #1000 by removing tap:i18n-bundler

### DIFF
--- a/interface/.meteor/packages
+++ b/interface/.meteor/packages
@@ -6,7 +6,6 @@
 
 less
 tap:i18n
-tap:i18n-bundler
 jeeeyul:moment-with-langs
 raix:handlebar-helpers
 frozeman:animation-helper

--- a/interface/.meteor/versions
+++ b/interface/.meteor/versions
@@ -91,7 +91,6 @@ standard-minifier-css@1.0.7
 standard-minifier-js@1.0.7
 standard-minifiers@1.0.6
 tap:i18n@1.8.2
-tap:i18n-bundler@0.3.0
 templating@1.1.10
 templating-tools@1.0.4
 tracker@1.0.14

--- a/interface/project-tap.i18n
+++ b/interface/project-tap.i18n
@@ -1,5 +1,4 @@
 {
 	"helper_name": "i18n",
-	"supported_languages": ["de", "en", "es", "fa", "fr", "it", "ja", "ko", "nb", "nl", "pt", "sq", "zh", "zh-TW"],
-    "cdn_path": "i18n"
+	"supported_languages": ["de", "en", "es", "fa", "fr", "it", "ja", "ko", "nb", "nl", "pt", "sq", "zh", "zh-TW"]
 }


### PR DESCRIPTION
Removed tap:i18n-bundler and the i18n should work fine.

`tap:i18n-bundler` is a meteor package that bundles all i18n resources to the `public` directory on meteor startup. It aimed to make client preload i18n files and make these files available offline for Cordova. Base on the serverless design principle of Dapp, I believe that feature introduces more troubles than benefits for the mist browser.

The root cause of #1000 is that i18n-bundler failed to update languages to `app/public/i18n`.

Please review this PR with https://github.com/ethereum/meteor-dapp-wallet/pull/250 together.