### PR TITLE
Fixes Meteor startup error having a redirect to about:blank

### DIFF
--- a/modules/syncMinimongo.js
+++ b/modules/syncMinimongo.js
@@ -114,6 +114,14 @@ exports.frontendSync = function(coll) {
         coll.remove({});
 
         JSON.parse(dataStr).forEach(function(record) {
+            // On Meteor startup if a record contains a redirect to about:blank
+            // page, the application process crashes.
+            if(typeof(record.redirect) !== 'undefined') {
+                if(record.redirect.indexOf('//about:blank') > -1) {
+                    record.redirect = null;
+                }
+            }
+
             coll.insert(record);
         });
 


### PR DESCRIPTION
Similarly like in the issue #1002 I had an error while starting Mist, and it turned out that the problem was a strange redirect to the about:blank page (according to the code I've seen, .redirect should be equal to the .url). Interestingly, if the redirect is something like https://google.com, nothing bad happens.

```
{ position: 0,
  url: 'https://ethereum.org/',
  _id: 'browser',
  webviewId: 14,
  icon: null,
  appBar: null,
  name: 'Ethereum Project',
  permissions: { accounts: [ '0xccca739ae27bfaef223cbe58b665860d691de087' ] },
  redirect: 'http://about:blank',
  menuVisible: true }
```

This PR adds a quick fix on minimongo frontendSync, which removes a redirect to the about:blank page. (don't know if it has to remove it always or only if url != redirect)

I agree that the root of the problem is deeper, but I think that in general it makes the application more stable.

Let me know what do you think.