### PR TITLE
check for system-wide installation of nodes; dynamically populate node-menu

### DIFF
--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -59,6 +59,8 @@
                 "runTests": "Run tests",
                 "logFiles": "Show log file",
                 "ethereumNode": "Ethereum Node",
+                "starting": "starting",
+                "externalNode": "using external node",
                 "network": "Network",
                 "mainNetwork": "Main Network",
                 "startMining": "⛏ Start Mining (Testnet only)",

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -41,8 +41,6 @@ class EthereumNode extends EventEmitter {
         this._type = null;
         this._network = null;
 
-        getNodePath();
-
         this._socket = Sockets.get('node-ipc', Settings.rpcMode);
 
         this.on('data', _.bind(this._logNodeData, this));
@@ -329,13 +327,15 @@ class EthereumNode extends EventEmitter {
         this._network = network;
         this._type = nodeType;
 
-        const binPath = getNodePath(nodeType);
-
-        log.debug(`Start node using ${binPath}`);
-
         return new Q((resolve, reject) => {
-            this.__startProcess(nodeType, network, binPath)
-                .then(resolve, reject);
+            getNodePath.probe()
+            .then(() => {
+                const binPath = getNodePath.query(nodeType);
+                log.debug(`Start node using ${binPath}`);
+
+                this.__startProcess(nodeType, network, binPath)
+                    .then(resolve, reject);
+            });
         });
     }
 

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -330,7 +330,7 @@ class EthereumNode extends EventEmitter {
         return new Q((resolve, reject) => {
             getNodePath.probe()
             .then(() => {
-                const binPath = getNodePath.query()[nodeType];
+                const binPath = Object.keys(getNodePath.query()[nodeType])[0];
                 log.debug(`Start node using ${binPath}`);
 
                 this.__startProcess(nodeType, network, binPath)

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -41,8 +41,6 @@ class EthereumNode extends EventEmitter {
         this._type = null;
         this._network = null;
 
-        getNodePath.probe();
-
         this._socket = Sockets.get('node-ipc', Settings.rpcMode);
 
         this.on('data', _.bind(this._logNodeData, this));

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -34,7 +34,7 @@ class EthereumNode extends EventEmitter {
         super();
 
         this.STATES = STATES;
-        
+
         this._loadDefaults();
 
         this._node = null;
@@ -333,10 +333,10 @@ class EthereumNode extends EventEmitter {
 
         log.debug(`Start node using ${binPath}`);
 
-    return new Q((resolve, reject) => {
-                this.__startProcess(nodeType, network, binPath)
-                    .then(resolve, reject);
-            });        
+        return new Q((resolve, reject) => {
+            this.__startProcess(nodeType, network, binPath)
+                .then(resolve, reject);
+        });
     }
 
 

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -14,6 +14,7 @@ const Q = require('bluebird');
 const getNodePath = require('./getNodePath.js');
 const EventEmitter = require('events').EventEmitter;
 const Sockets = require('./sockets');
+const SocketsBase = require('./sockets/base.js');
 const Settings = require('./settings');
 
 const DEFAULT_NODE_TYPE = 'geth';
@@ -328,7 +329,7 @@ class EthereumNode extends EventEmitter {
         this._type = nodeType;
 
         return new Q((resolve, reject) => {
-            getNodePath.probe()
+            Q.all(SocketsBase.getNodePathProm)
             .then(() => {
                 const binPath = Object.keys(getNodePath.query()[nodeType])[0];
                 log.debug(`Start node using ${binPath}`);

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -34,12 +34,14 @@ class EthereumNode extends EventEmitter {
         super();
 
         this.STATES = STATES;
-
+        
         this._loadDefaults();
 
         this._node = null;
         this._type = null;
         this._network = null;
+
+        getNodePath();
 
         this._socket = Sockets.get('node-ipc', Settings.rpcMode);
 
@@ -331,10 +333,10 @@ class EthereumNode extends EventEmitter {
 
         log.debug(`Start node using ${binPath}`);
 
-        return new Q((resolve, reject) => {
-            this.__startProcess(nodeType, network, binPath)
-                .then(resolve, reject);
-        });
+    return new Q((resolve, reject) => {
+                this.__startProcess(nodeType, network, binPath)
+                    .then(resolve, reject);
+            });        
     }
 
 

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -41,6 +41,8 @@ class EthereumNode extends EventEmitter {
         this._type = null;
         this._network = null;
 
+        getNodePath.probe();
+
         this._socket = Sockets.get('node-ipc', Settings.rpcMode);
 
         this.on('data', _.bind(this._logNodeData, this));
@@ -330,7 +332,7 @@ class EthereumNode extends EventEmitter {
         return new Q((resolve, reject) => {
             getNodePath.probe()
             .then(() => {
-                const binPath = getNodePath.query(nodeType);
+                const binPath = getNodePath.query()[nodeType];
                 log.debug(`Start node using ${binPath}`);
 
                 this.__startProcess(nodeType, network, binPath)

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -143,7 +143,7 @@ module.exports = {
                     for (let type in paths) {
                         for (let path in paths[type]) {
                             getVersionProms.push(getVersion(type, path)
-                            .then((data)=>{
+                            .then((data) => {
                                 var version = data.match(/[\d.]+/)[0];
                                 paths[type][path] = version;
                             }));

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -6,10 +6,10 @@ Gets the right Node path
 @module getNodePath
 */
 
-const path = require('path');
 const fs = require('fs');
-const exec = require('child_process').exec;
+const path = require('path');
 const Q = require('bluebird');
+const exec = require('child_process').exec;
 const cmpVer = require('semver-compare');
 const binaryPath = path.resolve(__dirname + '/../nodes');
 const log = require('./utils/logger').create('getNodePath');
@@ -73,71 +73,84 @@ function compareNodes() {
 }
 
 
-/**
- * Get paths of all nodes, returns system or bundled path depending on the latest version
- *
- * @param  {String} type   the type of node (i.e. 'geth', 'eth')
- */
-module.exports = function(type) {
-    if (resolvedPaths[type])
-        return resolvedPaths[type];
-    
-    return new Q((resolve, reject) => {
-        if(Settings.inProductionMode) {
-            var binPath = binaryPath.replace('nodes','node').replace('app.asar/','').replace('app.asar\\','');
-            
-            if(process.platform === 'darwin') {
-                binPath = path.resolve(binPath.replace('/node', '/../Frameworks/node'));
-            }
-
-            fs.readdirSync(binPath).forEach((type) => {
-                var nodePath = binPath + '/' + type + '/' + type;
-
-                if(process.platform === 'win32') {
-                    nodePath = nodePath.replace(/\/+/,'\\');
-                    nodePath += '.exe';
+module.exports = {
+    /**
+     * Returns path of node
+     * linux and mac only: returns system or bundled path depending on the latest version
+     *
+     * @param  {String} type   the type of node (i.e. 'geth', 'eth')
+     */
+    query: (type) => {
+      return resolvedPaths[type];   
+    },
+    /**
+     * Evaluates node paths
+     *  - Enumerates bundled nodes
+     * linux and mac only:
+     *  - probes for system installation of nodes
+     *  - compares the versions of bundled and system nodes (preferes latest version)
+     */
+    probe: () => {    
+        return new Q((resolve, reject) => {
+            if(Settings.inProductionMode) {
+                var binPath = binaryPath.replace('nodes','node').replace('app.asar/','').replace('app.asar\\','');
+                
+                if(process.platform === 'darwin') {
+                    binPath = path.resolve(binPath.replace('/node', '/../Frameworks/node'));
                 }
 
-                paths[type] = {};
-                paths[type][nodePath] = null;
-            });
-        } else {
-            fs.readdirSync('nodes/').forEach((type) => {
-                if (fs.statSync('nodes/' + type).isDirectory()) {
-                    var nodePath = path.resolve('nodes/' + type + '/' + process.platform +'-'+ process.arch + '/' + type);
+                fs.readdirSync(binPath).forEach((type) => {
+                    var nodePath = binPath + '/' + type + '/' + type;
+
+                    if(process.platform === 'win32') {
+                        nodePath = nodePath.replace(/\/+/,'\\');
+                        nodePath += '.exe';
+                    }
+
                     paths[type] = {};
                     paths[type][nodePath] = null;
-                }
-            });
-        }
-        
-        if (process.platform === 'linux' || process.platform === 'darwin') {
-            var getPathProms = [],
-                getVersionProms = [];
-
-            for (let type in paths) {
-                getPathProms.push(getSystemPath(type)
-                    .then((data) => {
-                        paths[type][data.match(/(\/\w+)+/)[0]] = null;
-                }));
-            }
-
-            Q.all(getPathProms).then(() => {
-                for (let type in paths) {
-                    for (let path in paths[type]) {
-                        getVersionProms.push(getVersion(type, path)
-                        .then((data)=>{
-                            var version = data.match(/[\d.]+/)[0];
-                            paths[type][path] = version;
-                        }));
+                });
+            } else {
+                fs.readdirSync('nodes/').forEach((type) => {
+                    if (fs.statSync('nodes/' + type).isDirectory()) {
+                        var nodePath = path.resolve('nodes/' + type + '/' + process.platform +'-'+ process.arch + '/' + type);
+                        paths[type] = {};
+                        paths[type][nodePath] = null;
                     }
+                });
+            }
+            
+            if (process.platform === 'linux' || process.platform === 'darwin') {
+                var getPathProms = [],
+                    getVersionProms = [];
+
+                for (let type in paths) {
+                    getPathProms.push(getSystemPath(type)
+                        .then((data) => {
+                            paths[type][data.match(/(\/\w+)+/)[0]] = null;
+                    }));
                 }
-            }).then(() => {
-                Q.all(getVersionProms).then(() => {
-                    compareNodes();
-                    log.debug('Available backends: %j', paths);
+
+                Q.all(getPathProms).then(() => {
+                    for (let type in paths) {
+                        for (let path in paths[type]) {
+                            getVersionProms.push(getVersion(type, path)
+                            .then((data)=>{
+                                var version = data.match(/[\d.]+/)[0];
+                                paths[type][path] = version;
+                            }));
+                        }
+                    }
+                }).then(() => {
+                    Q.all(getVersionProms).then(() => {
+                        compareNodes();
+                        log.debug('Available backends: %j', paths);
+                    })                    
+                    .then(resolve, reject);
                 })
-            });
-        }
-    });
+            } else {
+                resolve();
+            }
+        });
+    }
 }

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -71,7 +71,7 @@ module.exports = function(type) {
     }
 
     if(Settings.inProductionMode) {
-        binPath = binPath.replace('nodes','node').replace('app.asar/','').replace('app.asar\\','');
+        var binPath = binaryPath.replace('nodes','node').replace('app.asar/','').replace('app.asar\\','');
         
         if(process.platform === 'darwin') {
             binPath = path.resolve(binPath.replace('/node', '/../Frameworks/node'));
@@ -81,8 +81,8 @@ module.exports = function(type) {
             var nodePath = binPath + '/' + type + '/' + type;
 
             if(process.platform === 'win32') {
-                binPath += '.exe';
-                binPath = binPath.replace(/\/+/,'\\');
+                nodePath = nodePath.replace(/\/+/,'\\');
+                nodePath += '.exe';
             }
 
             paths[type] = {};
@@ -114,7 +114,5 @@ module.exports = function(type) {
         }
 
         log.debug('Available backends: %j', paths);
-
-        return resolvedPaths[type];
     }, 3000); 
 }

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -80,18 +80,18 @@ module.exports = {
      *
      * @param  {String} type   the type of node (i.e. 'geth', 'eth')
      */
-    query: (type) => {
-      return resolvedPaths[type];
+    query: () => {
+        return resolvedPaths;
     },
     /**
      * Evaluates node paths
      *  - Enumerates bundled nodes
      * linux and mac only:
      *  - probes for system installation of nodes
-     *  - compares the versions of bundled and system nodes (preferes latest version)
+     *  - compares the versions of bundled and system nodes (preferres latest version)
      */
     probe: () => {    
-        return new Q((resolve, reject) => {
+        return new Q((resolve, reject) => {                        
             if(Settings.inProductionMode) {
                 var binPath = binaryPath.replace('nodes','node').replace('app.asar/','').replace('app.asar\\','');
                 

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -66,33 +66,25 @@ function getVersion(type) {
  * @param  {String} type   the type of node (i.e. 'geth', 'eth')
  */
 module.exports = function(type) {
-    // return path if already resolved
     if (resolvedPaths[type]) {
         return resolvedPaths[type];
     }
 
-    // resolve base path of bundled nodes
-    var binPath = (Settings.inProductionMode)
-        ? binaryPath.replace('nodes','node')
-        : binaryPath
-
     if(Settings.inProductionMode) {
-        binPath = binPath.replace('app.asar/','').replace('app.asar\\','');
+        binPath = binPath.replace('nodes','node').replace('app.asar/','').replace('app.asar\\','');
         
         if(process.platform === 'darwin') {
             binPath = path.resolve(binPath.replace('/node', '/../Frameworks/node'));
         }
 
-        if(process.platform === 'win32') {
-            binPath += '/' + type + '/' + type + '.exe';
-            binPath = binPath.replace(/\/+/,'\\');
-        }
-    }
-
-    // resolve node binary paths
-    if (Settings.inProductionMode) {
         fs.readdirSync(binPath).forEach((type) => {
             var nodePath = binPath + '/' + type + '/' + type;
+
+            if(process.platform === 'win32') {
+                binPath += '.exe';
+                binPath = binPath.replace(/\/+/,'\\');
+            }
+
             paths[type] = {};
             paths[type][nodePath] = null;
         });
@@ -106,10 +98,10 @@ module.exports = function(type) {
         });
     }
 
-    // compare versions to system-wide installed nodes (only linux and mac)
-    if (process.platform === 'linux' || process.platform === 'darwin')
+    if (process.platform === 'linux' || process.platform === 'darwin') {
         for (var type in paths)
             getVersion(type, getSystemPath(type));
+    }
 
     setTimeout(() => {
         for (type in paths) {

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -7,52 +7,135 @@ Gets the right Node path
 */
 
 const path = require('path');
+const fs = require('fs');
+const exec = require('child_process').exec;
+const cmpVer = require('semver-compare');
 const binaryPath = path.resolve(__dirname + '/../nodes');
 const log = require('./utils/logger').create('getNodePath');
 const Settings = require('./settings');
 
 
 // cache
-const resolvedPaths = {};
+var paths = {},        // all versions (system + bundled):  { type: { path: version } }
+    resolvedPaths = {};  // latest version:                   { type: path }
+    
+const resolvedPathsOld = {};  // latest version:                   { type: path }
 
 
-module.exports = function(type) {
+
+/**
+ * Get path of system node
+ *
+ * @param  {String} type   the type of node (i.e. 'geth', 'eth')
+ */
+function getSystemPath(type) {
+    var proc = exec('type ' + type, (e, stdout, stderr) => {
+        if (!e)
+            // create new entry for path without version
+            paths[type][stdout.match(/(\/\w+)+/)[0]] = null;
+    });
+}
+
+
+/**
+ * Get versions of node (system and bundled)
+ *
+ * @param  {String} type   the type of node (i.e. 'geth', 'eth')
+ */
+function getVersion(type) {
+    setTimeout(() => {
+        for (var path in paths[type]) {
+            switch (type) {
+                case 'geth':
+                    var command = 'echo ' + path + ' && ' + path + ' version';  // stupid, use echo to pass path variable)
+                    break;
+                case 'eth':
+                case 'parity':
+                    var command = 'echo ' + path + ' && ' + path + ' --version';
+                    break;
+            }
+            var proc = exec(command, (e, stdout, stderr) => {
+                if (!e) {
+                    // add version to path entry
+                    var path = stdout.match(/(\/.+)+/)[0];
+                    var version = stdout.match(/[\d.]{3,}/)[0];
+                    paths[type][path] = version;
+                }
+            });
+        }
+    }, 50); // 3ms are sufficient on a SSD macbookpro for getSystemPath(type)
+}
+
+
+/**
+ * Scans for bundled nodes
+ */
+ function getBundledNodes() {
+    fs.readdirSync('nodes/').forEach((type) => {
+        if (fs.statSync('nodes/' + type).isDirectory()) // .DS_Store files... ??
+            fs.readdirSync('nodes/' + type).forEach((platform) => {
+            if (platform.indexOf(process.platform) !== -1) {
+                // this structure triggers the inculsion of a node type
+                var nodePath = path.resolve('nodes/' + type + '/' + platform + '/' + type);
+                paths[type] = {};
+                paths[type][nodePath] = null;
+            }
+        });
+    });
+}
+
+
+/**
+ * Get paths of all nodes, returns system or bundled path depending on the latest version
+ */
+/*
+function getNodePaths() {
+    getBundledNodes();
+    log.warn(paths);
+
+    for (var type in paths) {
+        getVersion(type, getSystemPath(type));
+    }
+
+    setTimeout(() => {
+        // console.log(paths);  // diplays all nodes, paths + versions
+        for (type in paths) {
+            var path = Object.keys(paths[type])[0];
+            if (Object.keys(paths[type]).length > 1) {
+                path = (cmpVer(Object.keys(paths[type])[0], Object.keys(paths[type])[1])) ? Object.keys(paths[type])[0] : Object.keys(paths[type])[1]
+            }
+            resolvedPaths[type] = path;
+        }
+        log.info(resolvedPaths);
+        return resolvedPaths;
+    }, 1500); // 100ms (geth) / 900ms (eth) are sufficient on a SSD macbookpro (for two calls)
+}*/
+
+
+module.exports = function(type) {   
     if (resolvedPaths[type]) {
         return resolvedPaths[type];
     }
 
-    let ret = '';
+    getBundledNodes();
 
-    // global override?
-    let globallySetType = Settings[`${type}Path`];
-    
-    if (globallySetType) {
-        resolvedPaths[type] = globallySetType;
-    } else {
-        var binPath = (Settings.inProductionMode)
-            ? binaryPath.replace('nodes','node') + '/'+ type +'/'+ type
-            : binaryPath + '/'+ type +'/'+ process.platform +'-'+ process.arch + '/'+ type;
-
-        if(Settings.inProductionMode) {
-            binPath = binPath.replace('app.asar/','').replace('app.asar\\','');
-            
-            if(process.platform === 'darwin') {
-                binPath = path.resolve(binPath.replace('/node/', '/../Frameworks/node/'));
-            }
-        }
-
-
-        if(process.platform === 'win32') {
-            binPath = binPath.replace(/\/+/,'\\');
-            binPath += '.exe';
-        }
-
-        resolvedPaths[type] = binPath;
+    for (var type in paths) {
+        getVersion(type, getSystemPath(type));
     }
 
-    log.debug(`Resolved path for ${type}: ${resolvedPaths[type]}`);
+    setTimeout(() => {
+        // console.log(paths);  // diplays all nodes, paths + versions
+        for (type in paths) {
+            var path = Object.keys(paths[type])[0];
+            if (Object.keys(paths[type]).length > 1) {
+                path = (cmpVer(Object.keys(paths[type])[0], Object.keys(paths[type])[1])) ? Object.keys(paths[type])[0] : Object.keys(paths[type])[1]
+            }
+            resolvedPaths[type] = path;
+        }
 
-    return resolvedPaths[type];
-};
+        log.info('Available backends: %j', resolvedPaths);    
 
+        return resolvedPaths[type];
+    }, 1500); // 100ms (geth) / 900ms (eth) are sufficient on a SSD macbookpro (for two calls)
+}
 

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -84,8 +84,8 @@ module.exports = function(type) {
         }
 
         if(process.platform === 'win32') {
+            binPath += '/' + type + '/' + type + '.exe';
             binPath = binPath.replace(/\/+/,'\\');
-            binPath += '.exe';
         }
     }
 

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -56,7 +56,7 @@ function getVersion(type) {
                 }
             });
         }
-    }, 50); // 3ms are sufficient on a SSD macbookpro for getSystemPath(type)
+    }, 200); 
 }
 
 
@@ -121,8 +121,8 @@ module.exports = function(type) {
             resolvedPaths[type] = path;
         }
 
-        log.info('Prefered backends: %j', resolvedPaths);    
+        log.debug('Available backends: %j', paths);
 
         return resolvedPaths[type];
-    }, 1500); // 100ms (geth) / 900ms (eth) are sufficient on a SSD macbookpro for two calls (bundled and system)
+    }, 3000); 
 }

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -152,7 +152,14 @@ module.exports = {
                 }).then(() => {
                     Q.all(getVersionProms).then(() => {
                         compareNodes();
-                        log.debug('Available backends: %j', paths);
+                        log.debug('Available backends:');
+                        Object.keys(paths).forEach((type) => {
+                            let i = 0;
+                            for (let path in paths[type]) {
+                                var name = (0 === i++) ? type + ' -' : type.replace(/./g, ' ') + '  '
+                                log.debug(name, paths[type][path], '=>', path);
+                            }
+                        });
                     })                    
                     .then(resolve, reject);
                 })

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -18,9 +18,6 @@ const Settings = require('./settings');
 // cache
 var paths = {},        // all versions (system + bundled):  { type: { path: version } }
     resolvedPaths = {};  // latest version:                   { type: path }
-    
-const resolvedPathsOld = {};  // latest version:                   { type: path }
-
 
 
 /**
@@ -31,7 +28,6 @@ const resolvedPathsOld = {};  // latest version:                   { type: path 
 function getSystemPath(type) {
     var proc = exec('type ' + type, (e, stdout, stderr) => {
         if (!e)
-            // create new entry for path without version
             paths[type][stdout.match(/(\/\w+)+/)[0]] = null;
     });
 }
@@ -88,54 +84,27 @@ function getVersion(type) {
 /**
  * Get paths of all nodes, returns system or bundled path depending on the latest version
  */
-/*
-function getNodePaths() {
-    getBundledNodes();
-    log.warn(paths);
-
-    for (var type in paths) {
-        getVersion(type, getSystemPath(type));
-    }
-
-    setTimeout(() => {
-        // console.log(paths);  // diplays all nodes, paths + versions
-        for (type in paths) {
-            var path = Object.keys(paths[type])[0];
-            if (Object.keys(paths[type]).length > 1) {
-                path = (cmpVer(Object.keys(paths[type])[0], Object.keys(paths[type])[1])) ? Object.keys(paths[type])[0] : Object.keys(paths[type])[1]
-            }
-            resolvedPaths[type] = path;
-        }
-        log.info(resolvedPaths);
-        return resolvedPaths;
-    }, 1500); // 100ms (geth) / 900ms (eth) are sufficient on a SSD macbookpro (for two calls)
-}*/
-
-
 module.exports = function(type) {   
-    if (resolvedPaths[type]) {
+    if (resolvedPaths[type])
         return resolvedPaths[type];
-    }
 
     getBundledNodes();
 
-    for (var type in paths) {
-        getVersion(type, getSystemPath(type));
-    }
+    if (process.platform === 'linux' || process.platform === 'darwin')
+        for (var type in paths)
+            getVersion(type, getSystemPath(type));
 
     setTimeout(() => {
-        // console.log(paths);  // diplays all nodes, paths + versions
         for (type in paths) {
             var path = Object.keys(paths[type])[0];
-            if (Object.keys(paths[type]).length > 1) {
+            if (Object.keys(paths[type]).length > 1)
                 path = (cmpVer(Object.keys(paths[type])[0], Object.keys(paths[type])[1])) ? Object.keys(paths[type])[0] : Object.keys(paths[type])[1]
-            }
             resolvedPaths[type] = path;
         }
 
         log.info('Available backends: %j', resolvedPaths);    
 
         return resolvedPaths[type];
-    }, 1500); // 100ms (geth) / 900ms (eth) are sufficient on a SSD macbookpro (for two calls)
+    }, 1500); // 100ms (geth) / 900ms (eth) are sufficient on a SSD macbookpro for two calls (bundled and system)
 }
 

--- a/modules/getNodePath.js
+++ b/modules/getNodePath.js
@@ -81,7 +81,7 @@ module.exports = {
      * @param  {String} type   the type of node (i.e. 'geth', 'eth')
      */
     query: (type) => {
-      return resolvedPaths[type];   
+      return resolvedPaths[type];
     },
     /**
      * Evaluates node paths
@@ -149,6 +149,12 @@ module.exports = {
                     .then(resolve, reject);
                 })
             } else {
+                for (let type in paths) {
+                    for (let path in paths[type]) {
+                        resolvedPaths[type] = path;
+                    }
+                }
+                log.debug('Available backends: %j', paths);
                 resolve();
             }
         });

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -349,9 +349,9 @@ var menuTempl = function(webviews) {
     });
     // add node switch
     if(process.platform === 'darwin' || process.platform === 'win32') {
-        var nodesMenu = [];
+        var nodes = [];
         for (let type in getNodePath.query())
-            nodesMenu.push({
+            nodes.push({
                 label: type.charAt(0).toUpperCase() + type.slice(1),
                 checked: ethereumNode.isOwnNode && ethereumNode.type === type,
                 enabled: ethereumNode.isOwnNode,
@@ -360,17 +360,29 @@ var menuTempl = function(webviews) {
                     restartNode(type);
                 }
             });
-        devToolsMenu.push({
-            label: i18n.t('mist.applicationMenu.develop.ethereumNode'),
-            submenu: nodesMenu
-        });
+        var submenu = { 'label': i18n.t('mist.applicationMenu.develop.ethereumNode') };
+        if (ethereumNode.state === undefined) {
+            submenu.label += ' (' + i18n.t('mist.applicationMenu.develop.starting') + ')';
+            submenu.enabled = false;
+        } else if (ethereumNode.isExternalNode) {
+            submenu.label += ' (' + i18n.t('mist.applicationMenu.develop.externalNode') + ')';
+            submenu.enabled = false;
+        } else if (nodes.length > 0) {
+            submenu.submenu =  nodes;
+        }
+        devToolsMenu.push(submenu);
     }
 
     // add network switch
-    devToolsMenu.push({
-        label: i18n.t('mist.applicationMenu.develop.network'),
-        submenu: [
-          {
+    var submenu = { label: i18n.t('mist.applicationMenu.develop.network') };
+    if (ethereumNode.state === undefined) {
+        submenu.label += ' (' + i18n.t('mist.applicationMenu.develop.starting') + ')';
+        submenu.enabled = false;
+    } else if (ethereumNode.isExternalNode) {
+        submenu.label += ' (' + i18n.t('mist.applicationMenu.develop.externalNode') + ')';
+        submenu.enabled = false;
+    } else {
+        submenu.submenu = [{
             label: i18n.t('mist.applicationMenu.develop.mainNetwork'),
             accelerator: 'CommandOrControl+Shift+1',
             checked: ethereumNode.isOwnNode && ethereumNode.isMainNetwork,
@@ -379,8 +391,8 @@ var menuTempl = function(webviews) {
             click: function(){
                 restartNode(ethereumNode.type, 'main');
             }
-          },
-          {
+        },
+        {
             label: 'Testnet (Morden)',
             accelerator: 'CommandOrControl+Shift+2',
             checked: ethereumNode.isOwnNode && ethereumNode.isTestNetwork,
@@ -389,8 +401,9 @@ var menuTempl = function(webviews) {
             click: function(){
                 restartNode(ethereumNode.type, 'test');
             }
-          }
-    ]});
+        }];
+    }
+    devToolsMenu.push(submenu);
 
     // add fork support
     devToolsMenu.push({

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -348,11 +348,13 @@ var menuTempl = function(webviews) {
         type: 'separator'
     });
     // add node switch
-    if(process.platform === 'darwin' || process.platform === 'win32') {
+    var resolvedPaths = getNodePath.query();
+    if (Object.keys(resolvedPaths).length > 1) {
         var nodes = [];
-        for (let type in getNodePath.query())
+        for (let type in resolvedPaths)
             nodes.push({
-                label: type.charAt(0).toUpperCase() + type.slice(1),
+                label: type.charAt(0).toUpperCase() + type.slice(1) 
+                    + ' (' + resolvedPaths[type][Object.keys(resolvedPaths[type])[0]] + ')',
                 checked: ethereumNode.isOwnNode && ethereumNode.type === type,
                 enabled: ethereumNode.isOwnNode,
                 type: 'checkbox',

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -7,6 +7,7 @@ const shell = electron.shell;
 const log = require('./utils/logger').create('menuItems');
 const ipc = electron.ipcMain;
 const ethereumNode = require('./ethereumNode.js');
+const getNodePath = require('./getNodePath.js');
 const Windows = require('./windows');
 const updateChecker = require('./updateChecker');
 const Settings = require('./settings');
@@ -342,39 +343,27 @@ var menuTempl = function(webviews) {
         }
     ];
 
-
-
-
-
     // add node switching menu
     devToolsMenu.push({
         type: 'separator'
     });
     // add node switch
     if(process.platform === 'darwin' || process.platform === 'win32') {
-        devToolsMenu.push({
-            label: i18n.t('mist.applicationMenu.develop.ethereumNode'),
-            submenu: [
-              {
-                label: 'Geth 1.4.10 (Go)',
-                checked: ethereumNode.isOwnNode && ethereumNode.isGeth,
+        var nodesMenu = [];
+        for (let type in getNodePath.query())
+            nodesMenu.push({
+                label: type.charAt(0).toUpperCase() + type.slice(1),
+                checked: ethereumNode.isOwnNode && ethereumNode.type === type,
                 enabled: ethereumNode.isOwnNode,
                 type: 'checkbox',
                 click: function(){
-                    restartNode('geth');
+                    restartNode(type);
                 }
-              },
-              {
-                label: 'Eth 1.2.9 (C++) [no hardfork support!]',
-                /*checked: ethereumNode.isOwnNode && ethereumNode.isEth,
-                enabled: ethereumNode.isOwnNode,*/
-                enabled: false,
-                type: 'checkbox',
-                click: function(){
-                    restartNode('eth');
-                }
-              }
-        ]});
+            });
+        devToolsMenu.push({
+            label: i18n.t('mist.applicationMenu.develop.ethereumNode'),
+            submenu: nodesMenu
+        });
     }
 
     // add network switch

--- a/modules/sockets/base.js
+++ b/modules/sockets/base.js
@@ -12,6 +12,7 @@ const getNodePath = require('../getNodePath.js');
 const CONNECT_INTERVAL_MS = 1000;
 const CONNECT_TIMEOUT_MS = 3000;
 
+var getNodePathProm = [];
 
 /**
  * Socket connecting to Ethereum Node.
@@ -85,7 +86,7 @@ class Socket extends EventEmitter {
                             this._log.warn(`Connection failed, retrying after ${CONNECT_INTERVAL_MS}ms...`);
 
                             if (Object.keys(getNodePath.query()).length == 0)
-                                getNodePath.probe();
+                                getNodePathProm.push(getNodePath.probe());
 
                             connectTimerId = setTimeout(() => {
                                 this._socket.connect(connectConfig);
@@ -200,6 +201,7 @@ class Socket extends EventEmitter {
 
 
 exports.Socket = Socket;
+exports.getNodePathProm = getNodePathProm; 
 
 
 const STATE = exports.STATE = Socket.STATE = {

--- a/modules/sockets/base.js
+++ b/modules/sockets/base.js
@@ -5,6 +5,7 @@ const EventEmitter = require('events').EventEmitter;
 
 const _ = global._;
 const log = require('../utils/logger').create('Sockets');
+const getNodePath = require('../getNodePath.js');
 
 
 
@@ -82,6 +83,9 @@ class Socket extends EventEmitter {
                     this._socket.on('error', (err) => {
                         if (STATE.CONNECTING === this._state) {
                             this._log.warn(`Connection failed, retrying after ${CONNECT_INTERVAL_MS}ms...`);
+
+                            if (Object.keys(getNodePath.query()).length == 0)
+                                getNodePath.probe();
 
                             connectTimerId = setTimeout(() => {
                                 this._socket.connect(connectConfig);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "numeral": "^1.5.3",
     "os-timesync": "^1.0.6",
     "semver": "^5.1.0",
+    "semver-compare": "^1.0.0",
     "solc": "^0.3.1-1",
     "underscore": "^1.8.3",
     "uuid": "^2.0.2",


### PR DESCRIPTION
closes #264

This current state of this PR will make `getNodePaths.js` to:
- `getNodePaths.probe()`
  - enumerate bundled nodes
  - check if system-installation of the relevant nodes are available (only Linux and mac)
  - gather and compare their versions
  - store the relevant (latest version's) paths in a `resolvedPaths[type] => {type:{path:version}}` dictionary
  - takes about 800ms with bundled + system instances of geth + eth (macbook pro, SSD)
- `getNodePaths.query(nodeType)`
  - returns preferred path of node

Prefers the latest version of a chosen node. Also system installation of node has higher priority. 
#### TODO
- [x] abstract to make drag and drop addition of any node possible (like parity)
- [x] make develop and production compatible
- [x] use promises
  - [x] to collect external command's outputs
    - [ ] refactor promise structure (race conditions)
  - [x] to integrate with `ethereumNode.js`
- [x] debug log entries
- [x] start `probe()` as soon as initial node connection times out (don't wait the 3 seconds)
  - [x] promisify to prevent timeout
- [x] basic error handling
- [x] populate node menu labels dynamically
  - [x] add version string
  - [x] hide if only one node type is available 
  - [ ] initiate rebuild of appMenu (gives an error); don't wait for node startup to trigger repopulate
- [ ] rebase on #972 and #1228 once merged
