### PR TITLE
Fix bug in checking for daoFork

### DIFF
--- a/main.js
+++ b/main.js
@@ -331,8 +331,7 @@ var onReady = function() {
         // CHECK for legacy chain (FORK RELATED)
         Q.try(() => {
             // open the legacy chain message
-            console.log(Settings.loadUserData('daoFork'));
-            if (Settings.loadUserData('daoFork').trim() === 'false') {
+            if ((Settings.loadUserData('daoFork') || '').trim() === 'false') {
 
                 dialog.showMessageBox({
                     type: "warning",


### PR DESCRIPTION
Some users may have never run the version of the wallet which asks for choosing fork/no-fork. In such cases a `daoFork` file won't exist. This fix takes that into account.