### PR TITLE
Filter result of eth.accounts even for batch IPC calls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/modules/ipc/ipcProviderBackend.js
+++ b/modules/ipc/ipcProviderBackend.js
@@ -289,7 +289,10 @@ class IpcProviderBackend {
                         ? this._processors[finalPayload.method]
                         : this._processors.base;
 
-                    return processor.exec(conn, nonErrorPayloads);
+                    return processor.exec(
+                        conn, 
+                        isBatch ? nonErrorPayloads : nonErrorPayloads[0]
+                    );
                 } else {
                     return [];
                 }
@@ -304,7 +307,7 @@ class IpcProviderBackend {
                     if (p.error) {
                         finalResult.push(p);
                     } else {
-                        p = _.extend({}, p, ret.result.shift());
+                        p = _.extend({}, p, isBatch ? ret.shift() : ret);
 
                         let processor = (this._processors[p.method])
                             ? this._processors[p.method]

--- a/modules/ipc/ipcProviderWrapper.js
+++ b/modules/ipc/ipcProviderWrapper.js
@@ -26,7 +26,7 @@ ipc.on('ipcProvider-setWritable', function(e, writable){
 
 
 
-ipcProviderWrapper = {
+const ipcProviderWrapper = {
     writable: false,
 
     /**

--- a/modules/ipc/methods/base.js
+++ b/modules/ipc/methods/base.js
@@ -31,7 +31,8 @@ module.exports = class BaseProcessor {
 
         return conn.socket.send(payload, {
             fullResult: true,
-        });
+        })
+        .then((ret) => ret.result);
     }
 
 

--- a/modules/ipc/methods/base.js
+++ b/modules/ipc/methods/base.js
@@ -23,56 +23,14 @@ module.exports = class BaseProcessor {
     /**
      * Execute given request.
      * @param  {Object} conn    IPCProviderBackend connection data.
-     * @param  {Object|Array} payload JSON payload object
+     * @param  {Object|Array} payload  payload
      * @return {Promise}
      */
     exec (conn, payload) {
         this._log.trace('Execute request', payload);
 
-        const isBatch = _.isArray(payload);
-
-        const payloadList = isBatch ? payload : [payload];
-
-        // filter out payloads which already have an error
-        const finalPayload = _.filter(payloadList, (p) => {
-            return !p.error;
-        });
-
-        return Q.try(() => {
-            if (finalPayload.length) {
-                return conn.socket.send(finalPayload, {
-                    fullResult: true,
-                });
-            } else {
-                return [];
-            }
-        })
-        .then((ret) => {
-            let result = [];
-
-            _.each(payloadList, (p) => {
-                if (p.error) {
-                    result.push(p);
-                } else {
-                    p = _.extend({}, p, ret.result.shift());
-
-                    this.sanitizePayload(conn, p);
-
-                    result.push(p);
-                }
-            });
-
-            // if single payload
-            if (!isBatch) {
-                result = result[0];
-
-                // throw error if found
-                if (result.error) {
-                    throw result.error;
-                }
-            }
-
-            return result;
+        return conn.socket.send(payload, {
+            fullResult: true,
         });
     }
 
@@ -88,16 +46,47 @@ module.exports = class BaseProcessor {
 
 
     /**
-    Sanitize a request or response payload.
+    Sanitize a request payload.
 
-    This will modify the input payload object.
+    This may modify the input payload object.
 
     @param {Object} conn The connection.
     @param {Object} payload The request payload.
+    @param {Boolean} isPartOfABatch Whether it's part of a batch payload.
     */
-    sanitizePayload (conn, payload) {
-        this._log.trace('Sanitize payload', payload);
+    sanitizeRequestPayload (conn, payload, isPartOfABatch) {
+        this._log.trace('Sanitize request payload', payload);
+        
+        this._sanitizeRequestResponsePayload(conn, payload, isPartOfABatch);
+    }
 
+
+    /**
+    Sanitize a response payload.
+
+    This may modify the input payload object.
+
+    @param {Object} conn The connection.
+    @param {Object} payload The request payload.
+    @param {Boolean} isPartOfABatch Whether it's part of a batch payload.
+    */
+    sanitizeResponsePayload (conn, payload, isPartOfABatch) {
+        this._log.trace('Sanitize response payload', payload);
+        
+        this._sanitizeRequestResponsePayload(conn, payload, isPartOfABatch);
+    }
+    
+    
+    /**
+    Sanitize a request or response payload.
+
+    This may modify the input payload object.
+
+    @param {Object} conn The connection.
+    @param {Object} payload The request payload.
+    @param {Boolean} isPartOfABatch Whether it's part of a batch payload.
+    */
+    _sanitizeRequestResponsePayload (conn, payload, isPartOfABatch) {
         if (!_.isObject(payload)) {
             throw this.ERRORS.INVALID_PAYLOAD;
         }
@@ -111,10 +100,7 @@ module.exports = class BaseProcessor {
             delete payload.result;
 
             payload.error = this.ERRORS.METHOD_DENIED;
-        
         }
     }
-
-
 };
 

--- a/modules/ipc/methods/eth_accounts.js
+++ b/modules/ipc/methods/eth_accounts.js
@@ -12,24 +12,21 @@ module.exports = class extends BaseProcessor {
     /**
      * @override
      */
-    exec (conn, payload) {
-        return super.exec(conn, payload)
-        .then((ret) => {
-            this._log.trace('Got account list', ret.result);
+    sanitizeResponsePayload (conn, payload, isPartOfABatch) {
+        this._log.trace('Sanitize account list', payload.result);
 
-            // if not an admin connection then do a check
-            if (!this._isAdminConnection(conn)) {
-                let tab = db.getCollection('tabs').findOne({ webviewId: conn.id });
+        // if not an admin connection then do a check
+        if (!this._isAdminConnection(conn)) {
+            let tab = db.getCollection('tabs').findOne({ webviewId: conn.id });
 
-                if(_.get(tab, 'permissions.accounts')) {
-                    ret.result = _.intersection(ret.result, tab.permissions.accounts);
-                } else {
-                    ret.result = [];
-                }                
+            if(_.get(tab, 'permissions.accounts')) {
+                payload.result = _.intersection(payload.result, tab.permissions.accounts);
+            } else {
+                payload.result = [];
             }                
-
-            return ret;
-        });
+        }                
+        
+        return super.sanitizeResponsePayload(conn, payload, isPartOfABatch);
     }
 }
 

--- a/modules/ipc/methods/eth_compileSolidity.js
+++ b/modules/ipc/methods/eth_compileSolidity.js
@@ -15,7 +15,7 @@ module.exports = class extends BaseProcessor {
      */
     exec (conn, payload) {
         return Q.try(() => {
-            this._log.info('Compile solidity');
+            this._log.debug('Compile solidity');
 
             let output = solc.compile(payload.params[0], 1); // 1 activates the optimiser
 
@@ -38,6 +38,17 @@ module.exports = class extends BaseProcessor {
 
             return finalResult;
         });
+    }
+    
+    /**
+     * @override
+     */
+    sanitizeRequestPayload (conn, payload, isPartOfABatch) {
+        if (isPartOfABatch) {
+            throw this.ERRORS.BATCH_COMPILE_DENIED;
+        }
+        
+        return super.sanitizeRequestPayload(conn, payload, isPartOfABatch);
     }
 }
 

--- a/modules/ipc/methods/eth_sendTransaction.js
+++ b/modules/ipc/methods/eth_sendTransaction.js
@@ -11,6 +11,19 @@ const ipc = electron.ipcMain;
  * Process method: eth_sendTransaction
  */
 module.exports = class extends BaseProcessor {
+    
+    /**
+     * @override
+     */
+    sanitizeRequestPayload (conn, payload, isPartOfABatch) {
+        if (isPartOfABatch) {
+            throw this.ERRORS.BATCH_TX_DENIED;
+        }
+        
+        return super.sanitizeRequestPayload(conn, payload, isPartOfABatch);
+    }
+
+
     /**
      * @override
      */

--- a/modules/ipc/methods/eth_sendTransaction.js
+++ b/modules/ipc/methods/eth_sendTransaction.js
@@ -30,7 +30,7 @@ module.exports = class extends BaseProcessor {
     exec (conn, payload) {
         return new Q((resolve, reject) => {
             this._log.info('Ask user for password');
-
+            
             this._log.info(payload.params[0]);
 
             // validate data


### PR DESCRIPTION
This fixes a security issue raised earlier. Although `eth.accounts` are filtered according to what's visible to the active Mist tab it was still possible to retrieve all accounts by making the same call as part of a batch IPC request. This PR fixes that.