### PR TITLE
Change README.md to use 'Navigator' instead of 'Browser'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Mist Browser
+# Mist Navigator
 
 [![Join the chat at https://gitter.im/ethereum/mist](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ethereum/mist?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build status master branch ](https://build.ethdev.com/buildstatusimage?builder=Mist%20master%20branch)](https://build.ethdev.com/builders/Mist%20master%20branch/builds/-1)
 [![Build status develop branch ](https://build.ethdev.com/buildstatusimage?builder=Mist%20develop%20branch)](https://build.ethdev.com/builders/Mist%20develop%20branch/builds/-1)
 
-The Mist browser is the tool of choice to browse and use Ðapps.
+Mist is the tool of choice to browse and use Ðapps.
 
 For the Mist API see the [MISTAPI.md](MISTAPI.md).
 


### PR DESCRIPTION
Update the README to use the term 'Navigator' rather than 'Browser' to avoid confusion with web browsers like Chrome or Firefox. See Alex's comment on #821.