### PR TITLE
Remove engines key from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,5 @@
     "run-sequence": "^1.2.1",
     "shelljs": "^0.7.0",
     "spectron": "^3.2.2"
-  },
-  "engines": {
-    "node": ">4.3.0",
-    "electron": "1.0.1",
-    "atom-shell": "0.36.2"
   }
 }


### PR DESCRIPTION
Although we're using shrinkwrap we still need package.json deps to operate things properly so am leaving that in.