### PR TITLE
add rpm builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To create a binaries you need to install [`electron-builder` dependencies](https
     // tools for the windows binaries
     $ brew install Caskroom/cask/xquartz wine mono
     // tools for the Linux binaries
-    $ brew install gnu-tar libicns graphicsmagick xz
+    $ brew install gnu-tar libicns graphicsmagick xz rpm
     // general dependencies
     $ npm install -g meteor-build-client
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -433,6 +433,12 @@ gulp.task('build-dist', ['copy-i18n'], function(cb) {
                     "y": 142,
                     "type": "file"
                 }]
+            },
+            linux: {
+                target: [
+                    "deb",
+                    "rpm"
+                ]
             }
         },
         directories: {


### PR DESCRIPTION
closes https://github.com/ethereum/mist/issues/1190

 - [ ] CentOS and Fedora misses `libXss.so.1` (Requires installation of `libXScrnSaver`):
```
./Ethereum Wallet: error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory
```
http://gentoobrowse.randomdan.homeip.net/package/x11-libs/libXScrnSaver#depees