### PR TITLE
[installer] adjust name of installation-folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -403,7 +403,7 @@ gulp.task('build-dist', ['copy-i18n'], function(cb) {
     console.log('Bundling platforms: ', options.platform);
 
     var appPackageJson = _.extend({}, packJson, {
-        name: applicationName.replace(/\s+/g, "-"),
+        name: applicationName.replace(/\s/, ''),
         productName: applicationName,
         description: applicationName,
         homepage: "https://github.com/ethereum/mist",       

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -403,6 +403,7 @@ gulp.task('build-dist', ['copy-i18n'], function(cb) {
     console.log('Bundling platforms: ', options.platform);
 
     var appPackageJson = _.extend({}, packJson, {
+        name: applicationName.replace(/\s+/g, "-"),,
         productName: applicationName,
         description: applicationName,
         homepage: "https://github.com/ethereum/mist",       

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -403,7 +403,7 @@ gulp.task('build-dist', ['copy-i18n'], function(cb) {
     console.log('Bundling platforms: ', options.platform);
 
     var appPackageJson = _.extend({}, packJson, {
-        name: applicationName.replace(/\s+/g, "-"),,
+        name: applicationName.replace(/\s+/g, "-"),
         productName: applicationName,
         description: applicationName,
         homepage: "https://github.com/ethereum/mist",       


### PR DESCRIPTION
fixes https://github.com/ethereum/mist/issues/1178

There is some minor problem with the package name..
**electron-builder**’s name variable will be used for linux and win as well:
 - win will use it as folder name under `%localappdata%` but will cut off anything starting with an {dash, space, point} as [NuGet will internally convert](https://github.com/Squirrel/Squirrel.Windows/blob/master/docs/using/nuget-package-metadata.md) - for example - spaces to `%20` but won't allow `%` for package ids
 - linux will use it as the package name in all lowercase

...best would be IMHO:
 - win: `Ethereum-Wallet`
 - linux: `ethereum-wallet`

...possible would be:
 - win: `EthereumWallet`
 - linux: `ethereumwallet`

**edit** 9/28: There might be a solution, follow the [white rabbit......](https://github.com/Squirrel/Squirrel.Windows/issues/530)