### PR TITLE
show node.log menuitem: open file instead of displaying exerpt

### DIFF
--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -58,6 +58,7 @@
                 "devToolsWebview": "__webview__",
                 "runTests": "Run tests",
                 "logFiles": "Show log file",
+                "externalNode": "using external node",
                 "ethereumNode": "Ethereum Node",
                 "network": "Network",
                 "mainNetwork": "Main Network",

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -330,7 +330,8 @@ var menuTempl = function(webviews) {
                 Windows.getByType('main').send('runTests', 'webview');
             }
         },{
-            label: i18n.t('mist.applicationMenu.develop.logFiles'),
+            label: i18n.t('mist.applicationMenu.develop.logFiles') + ' (' + i18n.t('mist.applicationMenu.develop.externalNode') + ')';
+            enabled: ethereumNode.isOwnNode, 
             click: function(){
                 try {
                     shell.showItemInFolder(Settings.userDataPath + '/node.log');

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -330,7 +330,7 @@ var menuTempl = function(webviews) {
                 Windows.getByType('main').send('runTests', 'webview');
             }
         },{
-            label: i18n.t('mist.applicationMenu.develop.logFiles') + ' (' + i18n.t('mist.applicationMenu.develop.externalNode') + ')';
+            label: i18n.t('mist.applicationMenu.develop.logFiles') + ' (' + i18n.t('mist.applicationMenu.develop.externalNode') + ')',
             enabled: ethereumNode.isOwnNode, 
             click: function(){
                 try {

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -332,7 +332,12 @@ var menuTempl = function(webviews) {
         },{
             label: i18n.t('mist.applicationMenu.develop.logFiles'),
             click: function(){
-                shell.showItemInFolder(Settings.userDataPath + '/node.log');
+                try {
+                    shell.showItemInFolder(Settings.userDataPath + '/node.log');
+                } catch(e){
+                    log.info(e);
+                    log = 'Couldn\'t load log file.';
+                };
             }
         }
     ];

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -332,22 +332,7 @@ var menuTempl = function(webviews) {
         },{
             label: i18n.t('mist.applicationMenu.develop.logFiles'),
             click: function(){
-                var log = '';
-                try {
-                    log = fs.readFileSync(Settings.userDataPath + '/node.log', {encoding: 'utf8'});
-                    log = '...'+ log.slice(-1000);
-                } catch(e){
-                    log.info(e);
-                    log = 'Couldn\'t load log file.';
-                };
-
-                dialog.showMessageBox({
-                    type: "info",
-                    buttons: ['OK'],
-                    message: 'Node log file',
-                    detail: log
-                }, function(){
-                });
+                shell.showItemInFolder(Settings.userDataPath + '/node.log');
             }
         }
     ];


### PR DESCRIPTION
This PR will open the folder containing the `node.log.X` files instead of opening a pop-up window with horizontally and vertically cropped node output.

Tested on win, linux and mac (on mac also the `node.log` file will be selected/highlighted).