### PR TITLE
update github's issue-template's node.log upload instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@ If possible add the following to your report:
 
 - Check the console, of Mist (`CTRL/CMD + ALT + i`) and take a screenshot
 
-- Log files (Go to `menu -> accounts -> backup -> application data` and upload as zip-archive):
-  -   osx: `~/Library/Application Support/Mist/node.log` 
-  -   windows: `%APPDATA%/Roaming/Mist/node.log`
-  -   linux: `~/.config/Mist/node.log`
+- Log files 
+  - go to `menu -> accounts -> backup -> application data`
+  - zip and upload `node.log` and all other `node.log.X` files 
+ 


### PR DESCRIPTION
The new installer splitted the config folder in separate ones for Ethereum Wallet and Mist, thus old paths in instructions are not valid anymore for Ethereum Wallet.