### PR TITLE
update string as 'v'-prefix was added to version tags

### DIFF
--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -47,7 +47,7 @@ const check = exports.check = function() {
         let latest = releases[0];
 
         if (semver.gt(latest.tag_name, Settings.appVersion)) {
-            log.info(`App (v${Settings.appVersion}) is out of date. New v${latest.tag_name} found.`);
+            log.info(`App (${Settings.appVersion}) is out of date. New v${latest.tag_name} found.`);
 
             return {
                 name: latest.name,


### PR DESCRIPTION
As we updated release tags to contain a 'v' as prefix - the current updater-popup will display the version tag as `vv0.8.4`.