### PR TITLE
update strings as 'v'-prefix was added to version tags

### DIFF
--- a/interface/client/templates/popupWindows/updateAvailable.html
+++ b/interface/client/templates/popupWindows/updateAvailable.html
@@ -15,7 +15,7 @@
                             {{i18n "mist.popupWindows.updateAvailable.newVersionAvailable" app=appName }}
                         </h1>
                         <button class="get-update">
-                            {{i18n "mist.popupWindows.updateAvailable.download"}} v{{version}}
+                            {{i18n "mist.popupWindows.updateAvailable.download"}} {{version}}
                         </button>                
                     {{/with}}
                 {{else}}

--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -47,7 +47,7 @@ const check = exports.check = function() {
         let latest = releases[0];
 
         if (semver.gt(latest.tag_name, Settings.appVersion)) {
-            log.info(`App (${Settings.appVersion}) is out of date. New v${latest.tag_name} found.`);
+            log.info(`App (${Settings.appVersion}) is out of date. New ${latest.tag_name} found.`);
 
             return {
                 name: latest.name,


### PR DESCRIPTION
Ups! Follow-up on https://github.com/ethereum/mist/pull/1245.
> As we updated release tags to contain a 'v' as prefix - the current updater-popup will display the version tag as `vv0.8.4`.