### PR TITLE
update geth to 1.4.17

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,23 +50,23 @@ var electronVersion = require('electron-prebuilt/package.json').version;
 var gethVersion = '1.4.17';
 var nodeUrls = {
     'mac-x64': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-darwin-10.6-amd64.tar.bz2',
+        url: 'https://bintray.com/artifact/download/luclu/ethereum/geth-1.4.17-stable-5a6008e-darwin-10.6-amd64.tar.bz2',
         ext: 'tar'
     },
     'linux-x64': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-linux-amd64.tar.bz2',
+        url: 'https://bintray.com/artifact/download/luclu/ethereum/geth-1.4.17-stable-5a6008e-linux-amd64.tar.bz2',
         ext: 'tar',
     },
     'linux-ia32': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-linux-386.tar.bz2',
+        url: 'https://bintray.com/artifact/download/luclu/ethereum/geth-1.4.17-stable-5a6008e-linux-386.tar.bz2',
         ext: 'tar',
     },
     'win-x64': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-windows-4.0-amd64.exe.zip',
+        url: 'https://bintray.com/artifact/download/luclu/ethereum/geth-1.4.17-stable-5a6008e-windows-4.0-amd64.exe.zip',
         ext: 'zip',
     },
     'win-ia32': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-windows-4.0-386.exe.zip',
+        url: 'https://bintray.com/artifact/download/luclu/ethereum/geth-1.4.17-stable-5a6008e-windows-4.0-386.exe.zip',
         ext: 'zip',
     },
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,26 +47,26 @@ var filenameLowercase = 'mist';
 var filenameUppercase = 'Mist';
 var applicationName = 'Mist'; 
 var electronVersion = require('electron-prebuilt/package.json').version;
-var gethVersion = '1.4.16';
+var gethVersion = '1.4.17';
 var nodeUrls = {
     'mac-x64': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.16-stable-6881525-darwin-10.6-amd64.tar.bz2',
+        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-darwin-10.6-amd64.tar.bz2',
         ext: 'tar'
     },
     'linux-x64': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.16-stable-6881525-linux-amd64.tar.bz2',
+        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-linux-amd64.tar.bz2',
         ext: 'tar',
     },
     'linux-ia32': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.16-stable-6881525-linux-386.tar.bz2',
+        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-linux-386.tar.bz2',
         ext: 'tar',
     },
     'win-x64': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.16-stable-6881525-windows-4.0-amd64.exe.zip',
+        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-windows-4.0-amd64.exe.zip',
         ext: 'zip',
     },
     'win-ia32': {
-        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.16-stable-6881525-windows-4.0-386.exe.zip',
+        url: 'https://bintray.com/artifact/download/karalabe/ethereum/geth-1.4.17-stable-6881525-windows-4.0-386.exe.zip',
         ext: 'zip',
     },
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -593,4 +593,3 @@ gulp.task('test-wallet', function() {
 
 
 gulp.task('default', ['mist']);
-

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -363,7 +363,7 @@ var menuTempl = function(webviews) {
             label: i18n.t('mist.applicationMenu.develop.ethereumNode'),
             submenu: [
               {
-                label: 'Geth 1.4.16 (Go)',
+                label: 'Geth 1.4.17 (Go)',
                 checked: ethereumNode.isOwnNode && ethereumNode.isGeth,
                 enabled: ethereumNode.isOwnNode,
                 type: 'checkbox',


### PR DESCRIPTION
Ready, geth-bins are hosted on [my bintray account](https://bintray.com/luclu/ethereum/geth/1.4.17-stable-5a6008e#files/) as Peter is on dotGo this week.