### PR TITLE
[packaging] add linux-zip; adapt package naming scheme

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -420,6 +420,12 @@ gulp.task('build-dist', ['copy-i18n'], function(cb) {
               "nodes/eth/${os}-${arch}",
               "nodes/geth/${os}-${arch}"
             ],
+            linux: {
+                target: [
+                    "zip",
+                    "deb"
+                ]
+            },
             dmg: {
                 background: "../build/dmg-background.jpg",
                 "icon-size": 128,
@@ -487,19 +493,28 @@ gulp.task('release-dist', ['build-dist'], function(done) {
         if (platformIsActive(osArch)) {
             switch (osArch) {
                 case 'win-ia32':
-                    shell.cp(path.join(distPath, 'win-ia32', `${applicationName} Setup ${version}-ia32.exe`), releasePath);
+                    shell.cp(path.join(distPath, 'win-ia32', `${applicationName} Setup ${version}-ia32.exe`),
+                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-win32-${version.replace(/\./g, '-')}.exe`));
                     break;
                 case 'win-x64':
-                    shell.cp(path.join(distPath, 'win', `${applicationName} Setup ${version}.exe`), releasePath);
+                    shell.cp(path.join(distPath, 'win', `${applicationName} Setup ${version}.exe`), path.join(releasePath, 
+                            `${applicationName.replace(/\s/, '-')}-win64-${version.replace(/\./g, '-')}.exe`));
                     break;
                 case 'mac-x64':
-                    shell.cp(path.join(distPath, 'mac', `${applicationName}-${version}.dmg`), releasePath);
+                    shell.cp(path.join(distPath, 'mac', `${applicationName}-${version}.dmg`), 
+                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-macosx-${version.replace(/\./g, '-')}.dmg`));
                     break;
                 case 'linux-ia32':
-                    shell.cp(path.join(distPath, `Mist-${version}-ia32.deb`), path.join(releasePath, `${applicationName}-${version}-ia32.deb`) );
+                    shell.cp(path.join(distPath, `${applicationName.replace(/\s/, '')}-${version}-ia32.deb`), 
+                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-linux32-${version.replace(/\./g, '-')}.deb`) );
+                    shell.cp(path.join(distPath, `${applicationName.replace(/\s/, '')}-${version}-ia32.zip`), 
+                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-linux32-${version.replace(/\./g, '-')}.zip`) );
                     break;
                 case 'linux-x64':
-                    shell.cp(path.join(distPath, `Mist-${version}.deb`), path.join(releasePath, `${applicationName}-${version}.deb`) );
+                    shell.cp(path.join(distPath, `${applicationName.replace(/\s/, '')}-${version}.deb`), 
+                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-linux64-${version.replace(/\./g, '-')}.deb`) );
+                    shell.cp(path.join(distPath, `${applicationName.replace(/\s/, '')}-${version}.zip`), 
+                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-linux64-${version.replace(/\./g, '-')}.zip`) );
                     break;
             }
         }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -529,9 +529,10 @@ gulp.task('get-release-checksums', function(done) {
     const releasePath = `./dist_${type}/release`;
 
     let files = fs.readdirSync(releasePath);
-
+    
+    shell.cd(releasePath);
     for (let file of files) {
-        let sha = shell.exec(`shasum -a 256 "./dist_${type}/release/${file}"`);
+        let sha = shell.exec(`shasum -a 256 "${file}"`);
 
         if (0 !== sha.code) {
             return done(new Error('Error executing shasum: ' + sha.stderr));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -489,32 +489,36 @@ gulp.task('release-dist', ['build-dist'], function(done) {
     shell.rm('-rf', releasePath);
     shell.mkdir('-p', releasePath);
 
+    let appNameHypen = applicationName.replace(/\s/, '-');
+    let appNameNoSpace = applicationName.replace(/\s/, '');
+    let versionDashed = version.replace(/\./g, '-');
+
     _.each(nodeUrls, (info, osArch) => {
         if (platformIsActive(osArch)) {
             switch (osArch) {
                 case 'win-ia32':
                     shell.cp(path.join(distPath, 'win-ia32', `${applicationName} Setup ${version}-ia32.exe`),
-                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-win32-${version.replace(/\./g, '-')}.exe`));
+                            path.join(releasePath, `${appNameHypen}-win32-${versionDashed}.exe`));
                     break;
                 case 'win-x64':
-                    shell.cp(path.join(distPath, 'win', `${applicationName} Setup ${version}.exe`), path.join(releasePath, 
-                            `${applicationName.replace(/\s/, '-')}-win64-${version.replace(/\./g, '-')}.exe`));
+                    shell.cp(path.join(distPath, 'win', `${applicationName} Setup ${version}.exe`), 
+                            path.join(releasePath, `${appNameHypen}-win64-${versionDashed}.exe`));
                     break;
                 case 'mac-x64':
                     shell.cp(path.join(distPath, 'mac', `${applicationName}-${version}.dmg`), 
-                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-macosx-${version.replace(/\./g, '-')}.dmg`));
+                            path.join(releasePath, `${appNameHypen}-macosx-${versionDashed}.dmg`));
                     break;
                 case 'linux-ia32':
-                    shell.cp(path.join(distPath, `${applicationName.replace(/\s/, '')}-${version}-ia32.deb`), 
-                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-linux32-${version.replace(/\./g, '-')}.deb`) );
-                    shell.cp(path.join(distPath, `${applicationName.replace(/\s/, '')}-${version}-ia32.zip`), 
-                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-linux32-${version.replace(/\./g, '-')}.zip`) );
+                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}-ia32.deb`), 
+                            path.join(releasePath, `${appNameHypen}-linux32-${versionDashed}.deb`) );
+                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}-ia32.zip`), 
+                            path.join(releasePath, `${appNameHypen}-linux32-${versionDashed}.zip`) );
                     break;
                 case 'linux-x64':
-                    shell.cp(path.join(distPath, `${applicationName.replace(/\s/, '')}-${version}.deb`), 
-                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-linux64-${version.replace(/\./g, '-')}.deb`) );
-                    shell.cp(path.join(distPath, `${applicationName.replace(/\s/, '')}-${version}.zip`), 
-                            path.join(releasePath, `${applicationName.replace(/\s/, '-')}-linux64-${version.replace(/\./g, '-')}.zip`) );
+                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}.deb`), 
+                            path.join(releasePath, `${appNameHypen}-linux64-${versionDashed}.deb`) );
+                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}.zip`), 
+                            path.join(releasePath, `${appNameHypen}-linux64-${versionDashed}.zip`) );
                     break;
             }
         }
@@ -530,9 +534,8 @@ gulp.task('get-release-checksums', function(done) {
 
     let files = fs.readdirSync(releasePath);
     
-    shell.cd(releasePath);
     for (let file of files) {
-        let sha = shell.exec(`shasum -a 256 "${file}"`);
+        let sha = shell.exec(`shasum -a 256 "${file}"`, { cwd:releasePath });
 
         if (0 !== sha.code) {
             return done(new Error('Error executing shasum: ' + sha.stderr));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ else
 var type = 'mist';
 var filenameLowercase = 'mist';
 var filenameUppercase = 'Mist';
-var applicationName = 'Mist'; 
+var applicationName = 'Mist';
 var electronVersion = require('electron-prebuilt/package.json').version;
 var gethVersion = '1.4.17';
 var nodeUrls = {
@@ -247,7 +247,7 @@ gulp.task('checkNodes', function(cb) {
             } catch (err) {
                 nodeUpdateNeeded = true;
             }
-        }        
+        }
     });
 
     cb();
@@ -335,7 +335,7 @@ gulp.task('copy-node-folder-files', ['checkNodes', 'clean:dist'], function(done)
 
 
 gulp.task('copy-files', [
-    'clean:dist', 
+    'clean:dist',
     'copy-app-folder-files',
     'copy-build-folder-files',
     'copy-node-folder-files',
@@ -406,7 +406,7 @@ gulp.task('build-dist', ['copy-i18n'], function(cb) {
         name: applicationName.replace(/\s/, ''),
         productName: applicationName,
         description: applicationName,
-        homepage: "https://github.com/ethereum/mist",       
+        homepage: "https://github.com/ethereum/mist",
         build: {
             appId: "com.ethereum.mist." + type,
             "category": "public.app-category.productivity",
@@ -457,7 +457,7 @@ gulp.task('build-dist', ['copy-i18n'], function(cb) {
 
     // Copy build script
     shell.cp(
-        path.join(__dirname, 'scripts', 'build-dist.js'), 
+        path.join(__dirname, 'scripts', 'build-dist.js'),
         path.join(__dirname, 'dist_' + type, 'app')
     );
 
@@ -489,9 +489,9 @@ gulp.task('release-dist', ['build-dist'], function(done) {
     shell.rm('-rf', releasePath);
     shell.mkdir('-p', releasePath);
 
-    let appNameHypen = applicationName.replace(/\s/, '-');
-    let appNameNoSpace = applicationName.replace(/\s/, '');
-    let versionDashed = version.replace(/\./g, '-');
+    const appNameHypen = applicationName.replace(/\s/, '-');
+    const appNameNoSpace = applicationName.replace(/\s/, '');
+    const versionDashed = version.replace(/\./g, '-');
 
     _.each(nodeUrls, (info, osArch) => {
         if (platformIsActive(osArch)) {
@@ -501,23 +501,23 @@ gulp.task('release-dist', ['build-dist'], function(done) {
                             path.join(releasePath, `${appNameHypen}-win32-${versionDashed}.exe`));
                     break;
                 case 'win-x64':
-                    shell.cp(path.join(distPath, 'win', `${applicationName} Setup ${version}.exe`), 
+                    shell.cp(path.join(distPath, 'win', `${applicationName} Setup ${version}.exe`),
                             path.join(releasePath, `${appNameHypen}-win64-${versionDashed}.exe`));
                     break;
                 case 'mac-x64':
-                    shell.cp(path.join(distPath, 'mac', `${applicationName}-${version}.dmg`), 
+                    shell.cp(path.join(distPath, 'mac', `${applicationName}-${version}.dmg`),
                             path.join(releasePath, `${appNameHypen}-macosx-${versionDashed}.dmg`));
                     break;
                 case 'linux-ia32':
-                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}-ia32.deb`), 
+                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}-ia32.deb`),
                             path.join(releasePath, `${appNameHypen}-linux32-${versionDashed}.deb`) );
-                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}-ia32.zip`), 
+                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}-ia32.zip`),
                             path.join(releasePath, `${appNameHypen}-linux32-${versionDashed}.zip`) );
                     break;
                 case 'linux-x64':
-                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}.deb`), 
+                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}.deb`),
                             path.join(releasePath, `${appNameHypen}-linux64-${versionDashed}.deb`) );
-                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}.zip`), 
+                    shell.cp(path.join(distPath, `${appNameNoSpace}-${version}.zip`),
                             path.join(releasePath, `${appNameHypen}-linux64-${versionDashed}.zip`) );
                     break;
             }
@@ -533,7 +533,7 @@ gulp.task('get-release-checksums', function(done) {
     const releasePath = `./dist_${type}/release`;
 
     let files = fs.readdirSync(releasePath);
-    
+
     for (let file of files) {
         let sha = shell.exec(`shasum -a 256 "${file}"`, { cwd:releasePath });
 


### PR DESCRIPTION
Sets file-names in `dist-${applicationName}/release` folder to:
```
Ethereum-Wallet-linux32-0-8-5.deb
Ethereum-Wallet-linux32-0-8-5.zip
Ethereum-Wallet-linux64-0-8-5.deb
Ethereum-Wallet-linux64-0-8-5.zip
Ethereum-Wallet-macosx-0-8-5.dmg
Ethereum-Wallet-win32-0-8-5.exe
Ethereum-Wallet-win64-0-8-5.exe
```
```
Mist-linux32-0-8-5.deb
Mist-linux32-0-8-5.zip
Mist-linux64-0-8-5.deb
Mist-linux64-0-8-5.zip
Mist-macosx-0-8-5.dmg
Mist-win32-0-8-5.exe
Mist-win64-0-8-5.exe
```