### PR TITLE
Allow for boolean options to get passed to geth/eth node

### DIFF
--- a/modules/settings.js
+++ b/modules/settings.js
@@ -19,8 +19,6 @@ try {
 
 
 
-
-
 const argv = require('yargs')
     .usage('Usage: $0 [Mist options] [Node options]')
     .option({
@@ -134,7 +132,10 @@ argv.nodeOptions = [];
 for (let optIdx in argv) {
     if (0 === optIdx.indexOf('node-')) {
         argv.nodeOptions.push('--' + optIdx.substr(5));
-        argv.nodeOptions.push(argv[optIdx]);
+        
+        if (true !== argv[optIdx]) {
+            argv.nodeOptions.push(argv[optIdx]);
+        }
 
         break;
     }


### PR DESCRIPTION
Fix for #1273. Now if you do `<mist executable> --node-ssh` it will pass `--ssh` onto Geth correctly without appending `true` to it.