### PR TITLE
[travis] add gitter notification webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,9 @@ script:
 notifications:
   email:
     - EMAIL
+  webhooks:
+    urls:
+      - YOUR_WEBHOOK_URL
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always
+    on_start: never


### PR DESCRIPTION
- compare go-ethereum: [.travis.yml#L40-L45](https://github.com/ethereum/go-ethereum/blob/develop/.travis.yml#L40-L45)
- env var already set in travis