### PR TITLE
[menu] backup appData: open appData folder instead of its parent

### DIFF
--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -187,7 +187,7 @@ let menuTempl = function (webviews) {
                     }, {
                         label: i18n.t('mist.applicationMenu.accounts.backupMist'),
                         click() {
-                            shell.showItemInFolder(Settings.userDataPath);
+                            shell.openItem(Settings.userDataPath);
                         },
                     },
                 ],


### PR DESCRIPTION
fixes https://github.com/ethereum/mist/issues/288