### PR TITLE
[ESLint] add meteor specific style guide

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,16 +1,16 @@
-extends:
-  - airbnb-base
-  - plugin:meteor/recommended
+extends: airbnb-base
 
 plugins:
   - import
-  - meteor
 
 settings:
   import/core-modules:  # don't lint for these missing packages in package.json
-    - electron  # 'electron-prebuilt' is being used
+    - electron  # 'electron' is only needed as devDependency / global installation
 
 rules:
   indent:
     - 2  # error
     - 4  # number of spaces
+
+globals:  # don't warn about missing declaration
+  i18n: true

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,7 +1,10 @@
-extends: airbnb-base
+extends:
+  - airbnb-base
+  - plugin:meteor/recommended
 
 plugins:
   - import
+  - meteor
 
 settings:
   import/core-modules:  # don't lint for these missing packages in package.json
@@ -11,6 +14,3 @@ rules:
   indent:
     - 2  # error
     - 4  # number of spaces
-
-globals:
-  i18n: true  # don't warn about missing 'i18n' declaration

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,8 @@ import/no-extraneous-dependencies,
 no-console,
 strict,
 prefer-spread,
-arrow-body-style */
+arrow-body-style,
+import/no-unresolved */
 
 'use strict';
 

--- a/interface/.eslintrc.yml
+++ b/interface/.eslintrc.yml
@@ -1,0 +1,3 @@
+globals:
+  i18n: true  # don't warn about missing 'i18n' declaration
+  Helpers: true  # don't warn about missing 'Helpers' declaration

--- a/interface/.eslintrc.yml
+++ b/interface/.eslintrc.yml
@@ -1,8 +1,5 @@
 env:  # don't warn about no-def meteor keywords
   meteor: true
 
-plugins:
-  - meteor
-
 rules:
   no-undef: 0

--- a/interface/.eslintrc.yml
+++ b/interface/.eslintrc.yml
@@ -1,3 +1,8 @@
-globals:
-  i18n: true  # don't warn about missing 'i18n' declaration
-  Helpers: true  # don't warn about missing 'Helpers' declaration
+env:  # don't warn about no-def meteor keywords
+  meteor: true
+
+plugins:
+  - meteor
+
+rules:
+  no-undef: 0

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^3.8.0",
     "eslint-config-airbnb-base": "^8.0.0",
     "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-meteor": "^4.0.1",
     "genomatic": "^1.0.0",
     "geth-private": "^1.3.0",
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint": "^3.8.0",
     "eslint-config-airbnb-base": "^8.0.0",
     "eslint-plugin-import": "^1.16.0",
-    "eslint-plugin-meteor": "^4.0.1",
     "genomatic": "^1.0.0",
     "geth-private": "^1.3.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Unfortunately ESLint is unable to relate to meteor's scopes, thus variables are recognized as undefined. There are two ways around this:
1. disable the `no-undef` rule for the `interface` directory 
2. add any defined variables in a config-comment line in each file specifically 
3. leverage `meteor lint` command (more complicated setup)

This PR currently opted for (1).

There is also a nice meteor-plugin for ESLint https://github.com/dferber90/eslint-plugin-meteor,
unfortunately it is [not yet supported by code-climate](https://docs.codeclimate.com/docs/eslint#section-eslint-3) and will error out.