### PR TITLE
Fixing mentionbot config file

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -7,5 +7,5 @@
   "fileBlacklist": ["*.md, signatures.js, interface/.meteor"],
   "skipAlreadyAssignedPR": false,
   "skipAlreadyMentionedPR": false,
-  "assignToReviewer": false,
+  "assignToReviewer": false
 }


### PR DESCRIPTION
This PR aims to fix the message:

> Unable to parse mention-bot custom configuration file due to a syntax error.
> Please check the potential root causes below:
> - Having comments
> - Invalid JSON type
> - Having extra "," in the last JSON attribute

