### PR TITLE
Restart ethblocks

### DIFF
--- a/interface/client/appStart.js
+++ b/interface/client/appStart.js
@@ -12,6 +12,8 @@ The init function of Mist
 mistInit = function(){
     console.info('Initialise Mist Interface');
 
+    EthBlocks.init();
+
     Tabs.onceSynced.then(function() {
         if (0 <= location.search.indexOf('reset-tabs')) {
             console.info('Resetting UI tabs');
@@ -55,8 +57,6 @@ Meteor.startup(function(){
     console.info('Meteor starting up...');
 
     EthAccounts.init();
-    EthBlocks.init();
-
     mistInit();
 
     console.debug('Setting language');


### PR DESCRIPTION
It’s a small fix that solves the issue of the sidebar not updating the blocks because ethBlocks is not keeping up with web3.eth.getBlocks.

On `nodeInfo.js`, whenever `syncing == true`, it will execute a `web3.reset(true);` which stops all listeners. But when syncing stops again it does a MistInit but not a EthBlocks.init(). So I’m putting the EthBlocks.init() inside MistInit so it will restart it. It’s not called elsewhere.