### PR TITLE
Update geth to 1.5.5 (#1520)

### DIFF
--- a/main.js
+++ b/main.js
@@ -407,7 +407,7 @@ onReady = () => {
                 });
             }
 
-            return Q.cancel();
+            return;
         })
         .then(function doSync() {
             // we're going to do the sync - so show splash
@@ -416,10 +416,10 @@ onReady = () => {
             }
 
             if (Settings.inAutoTestMode) {
-                return Q.cancel();
+                return syncResultPromise;
             }
 
-            return syncResultPromise;
+            return;
         })
         .then(function allDone() {
             startMainWindow();

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "numeral": "^1.5.3",
     "os-timesync": "^1.0.6",
     "semver": "^5.1.0",
-    "solc": "^0.4.5",
+    "solc": "0.4.5",
     "typescript": "^1.7.3",
     "underscore": "^1.8.3",
     "underscore-deep-extend": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "numeral": "^1.5.3",
     "os-timesync": "^1.0.6",
     "semver": "^5.1.0",
-    "solc": "0.4.5",
+    "solc": "0.4.6",
     "typescript": "^1.7.3",
     "underscore": "^1.8.3",
     "underscore-deep-extend": "^1.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,9 +3895,9 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-solc@^0.4.5:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.6.tgz#afa929a1ceafc0252cfbb4217c8e2b1dab139db7"
+solc@0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.5.tgz#921c4be798d1c22e2b77508db2adc00943ae1ecf"
   dependencies:
     fs-extra "^0.30.0"
     memorystream "^0.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,9 +3895,9 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-solc@0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.5.tgz#921c4be798d1c22e2b77508db2adc00943ae1ecf"
+solc@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.6.tgz#afa929a1ceafc0252cfbb4217c8e2b1dab139db7"
   dependencies:
     fs-extra "^0.30.0"
     memorystream "^0.3.1"


### PR DESCRIPTION
* Update geth to 1.5.5

* corrected windows zip's internal paths

* changed sanity check

* made node starting better

* also log path from which to fetch

* show fetching origin URL

* fix ESLint errors

* removed -stable