### PR TITLE
fixes the immediate startup issue

### DIFF
--- a/main.js
+++ b/main.js
@@ -415,7 +415,7 @@ onReady = () => {
                 splashWindow.show();
             }
 
-            if (Settings.inAutoTestMode) {
+            if (!Settings.inAutoTestMode) {
                 return syncResultPromise;
             }
 

--- a/modules/nodeSync.js
+++ b/modules/nodeSync.js
@@ -149,7 +149,7 @@ class NodeSync extends EventEmitter {
 
                                 const diff = now - +blockResult.timestamp;
 
-                                log.debug(`Last block: ${blockResult.number}, ${diff}s ago`);
+                                log.debug(`Last block: ${Number(blockResult.number)}, ${diff}s ago`);
 
                                 // need sync if > 1 minute
                                 if (diff > 60) {


### PR DESCRIPTION
This was introduced shortly before release. This means currently all Wallets and Mist start right away, no matter if its synced or not. This PR fixes this.