### PR TITLE
[yarn] add 'cd interface && yarn' postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/ethereum/mist.git"
   },
   "scripts": {
+    "postinstall": "cd interface && yarn",
     "ci": "gulp --platform=linux"
   },
   "main": "main.js",


### PR DESCRIPTION
Since meteor 1.4 the npm-module 'babel-runtime' needs to be installed into `interface/`.

This PR will add a postinstall hook to yarn (packages.json):
```
cd interface && yarn
```