### PR TITLE
fix offline-startup edge-case

### DIFF
--- a/modules/clientBinaryManager.js
+++ b/modules/clientBinaryManager.js
@@ -180,7 +180,9 @@ class Manager extends EventEmitter {
         .then((localConfig) => {
             if (!localConfig) {
                 log.info('No config for the ClientBinaryManager could be loaded, using local clientBinaries.json.');
-                localConfig = require('../clientBinaries.json');
+
+                const localConfigPath = path.join(Settings.userDataPath, 'clientBinaries.json');
+                localConfig = (fs.existsSync(localConfigPath)) ? require(localConfigPath) : require('../clientBinaries.json');  // eslint-disable-line no-param-reassign, global-require, import/no-dynamic-require, import/no-unresolved
             }
 
             // scan for node


### PR DESCRIPTION
fix https://github.com/ethereum/mist/issues/1569
Prefer the downloaded `clientBinaries.json` over the bundled one if offline.
This will prevent issues if the downloaded node's version isn't on parity with the bundled one.