### PR TITLE
update geth to 1.5.6

### DIFF
--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -2,36 +2,36 @@
 {
     "clients": {
         "Geth": {
-            "version": "1.5.5",
+            "version": "1.5.6",
             "platforms": {
                 "linux": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.5-ff07d548.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.6-2a609af5.tar.gz",
                             "type": "tar",
-                            "sha256": "4f36d6df25c37eb33829407d8bf2cea209cc412b3443319e2430db18581c7c01",
-                            "bin": "geth-linux-amd64-1.5.5-ff07d548/geth"
+                            "md5": "f004f4d599e2480aa6829bf4ac21ee37",
+                            "bin": "geth-linux-amd64-1.5.6-2a609af5/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.6" ]
                             }
                         }
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.5.5-ff07d548.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.5.6-2a609af5.tar.gz",
                             "type": "tar",
-                            "sha256": "6767651e4e5b34acaa6c53079d66a9047acb74e80fd25f570bf63da87d0ce863",
-                            "bin": "geth-linux-386-1.5.5-ff07d548/geth"
+                            "md5": "ef20de32332a36333a67571534499a6b",
+                            "bin": "geth-linux-386-1.5.6-2a609af5/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.6" ]
                             }
                         }
                     }
@@ -39,16 +39,16 @@
                 "mac": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.5.5-ff07d548.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.5.6-2a609af5.tar.gz",
                             "type": "tar",
-                            "sha256": "a5b3ae5b7e9d91a0ca42ca24b079631578cdccce036cc5b1f0035cd0d9706b53",
-                            "bin": "geth-darwin-amd64-1.5.5-ff07d548/geth"
+                            "md5": "b55b981e357d887e63d3b3b52bc68031",
+                            "bin": "geth-darwin-amd64-1.5.6-2a609af5/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.6" ]
                             }
                         }
                     }
@@ -56,31 +56,31 @@
                 "win": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-amd64-1.5.5-ff07d548-mist-fix.zip",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.5.6-2a609af5.zip",
                             "type": "zip",
-                            "sha256": "6b9e65ccac8a07535fbfd003662cdd4f69289f93947689c715d10c6486e703d7",
-                            "bin": "geth-windows-amd64-1.5.5-ff07d548\\geth.exe"
+                            "md5": "2b9eab7897bf4fdcb9577b73dc8a99b7",
+                            "bin": "geth-windows-amd64-1.5.6-2a609af5\\geth.exe"
                         },
                         "bin": "geth.exe",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.6" ]
                             }
                         }
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-386-1.5.5-ff07d548-mist-fix.zip",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.5.6-2a609af5.zip",
                             "type": "zip",
-                            "sha256": "74ef8372ae7748c1016a8fcfe2d49574b52a2780913081cf0184fb197f26f01c",
-                            "bin": "geth-windows-386-1.5.5-ff07d548\\geth.exe"
+                            "md5": "1a1574643defc8f790a96aca5fd77937",
+                            "bin": "geth-windows-386-1.5.6-2a609af5\\geth.exe"
                         },
                         "bin": "geth.exe",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.6" ]
                             }
                         }
                     }

--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -9,7 +9,7 @@
                         "download": {
                             "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.6-2a609af5.tar.gz",
                             "type": "tar",
-                            "md5": "f004f4d599e2480aa6829bf4ac21ee37",
+                            "sha256": "5d7fc44e0fa60dcca07a3894db14d1d5fccbe5bebad2b2bac94554ecefe784e0",
                             "bin": "geth-linux-amd64-1.5.6-2a609af5/geth"
                         },
                         "bin": "geth",
@@ -24,7 +24,7 @@
                         "download": {
                             "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.5.6-2a609af5.tar.gz",
                             "type": "tar",
-                            "md5": "ef20de32332a36333a67571534499a6b",
+                            "sha256": "7ec549171495fccca78b93a3eee4bdc7a69d69c9a257d8f780bc08a6babe3046",
                             "bin": "geth-linux-386-1.5.6-2a609af5/geth"
                         },
                         "bin": "geth",
@@ -41,7 +41,7 @@
                         "download": {
                             "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.5.6-2a609af5.tar.gz",
                             "type": "tar",
-                            "md5": "b55b981e357d887e63d3b3b52bc68031",
+                            "sha256": "d14201b6d14dde5a6ea9211bfb6b06ea718d91b4e85850bc221468373d492616",
                             "bin": "geth-darwin-amd64-1.5.6-2a609af5/geth"
                         },
                         "bin": "geth",
@@ -58,7 +58,7 @@
                         "download": {
                             "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.5.6-2a609af5.zip",
                             "type": "zip",
-                            "md5": "2b9eab7897bf4fdcb9577b73dc8a99b7",
+                            "sha256": "676bf720c5c19bbc32ca8602479c12c1cc614b1cbb61e792212efc1cc202539f",
                             "bin": "geth-windows-amd64-1.5.6-2a609af5\\geth.exe"
                         },
                         "bin": "geth.exe",
@@ -73,7 +73,7 @@
                         "download": {
                             "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.5.6-2a609af5.zip",
                             "type": "zip",
-                            "md5": "1a1574643defc8f790a96aca5fd77937",
+                            "sha256": "21a9e5535c1af854d4c335f5353f119905bdbb24ba42c35dc9a56462a6a3a0dc",
                             "bin": "geth-windows-386-1.5.6-2a609af5\\geth.exe"
                         },
                         "bin": "geth.exe",


### PR DESCRIPTION
Tested download on:
- [x] macos
- [ ] win32
- [ ] win64
- [x] linux32
- [x] linux64

**Update: geth 1.5.6 will be skipped as in favour of 1.5.7 as the current release is incompatible with Mist**