### PR TITLE
[mistAPI] add 'mist.solidity.version'

### DIFF
--- a/modules/preloader/include/mistAPI.js
+++ b/modules/preloader/include/mistAPI.js
@@ -56,6 +56,9 @@ module.exports = () => {
 
             ipcRenderer.send('mistAPI_requestAccount');
         },
+        solidity: {
+            version: packageJson.dependencies.solc,
+        },
         sounds: {
             bip: function playSound() {
                 ipcRenderer.sendToHost('mistAPI_sound', `file://${__dirname}/../../../sounds/bip.mp3`);

--- a/tests/mocha-in-browser/spec/general-spec.js
+++ b/tests/mocha-in-browser/spec/general-spec.js
@@ -26,6 +26,7 @@ describe('General', function () {
                 'requestAccount',
                 'sounds',
                 'menu',
+                'solidity'
             ];
 
             expect(mist).to.have.all.keys(allowedAttributes);
@@ -33,6 +34,10 @@ describe('General', function () {
 
         it('should return platform', function () {
             expect(mist.platform).to.be.oneOf(['darwin', 'win32', 'freebsd', 'linux', 'sunos']);
+        });
+
+        it('should report solidity version', function () {
+            expect(mist.solidity.version).to.match(/^\d\.\d{1,2}\.\d{1,2}$/); // match examples: 0.4.6, 0.5.10, 0.10.0
         });
     });
 


### PR DESCRIPTION
I still wonder if we should add `mist.compiler.solidity.version` instead?