### PR TITLE
Udpate geth to 1.5.7

### DIFF
--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -2,36 +2,36 @@
 {
     "clients": {
         "Geth": {
-            "version": "1.5.5",
+            "version": "1.5.7",
             "platforms": {
                 "linux": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.5-ff07d548.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.7-da2a22c3.tar.gz",
                             "type": "tar",
-                            "sha256": "4f36d6df25c37eb33829407d8bf2cea209cc412b3443319e2430db18581c7c01",
-                            "bin": "geth-linux-amd64-1.5.5-ff07d548/geth"
+                            "sha256": "49c52b4aa3a868d89a436af447158cf93c2f762375790d69364ea15e98af8d38",
+                            "bin": "geth-linux-amd64-1.5.7-da2a22c3/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.7" ]
                             }
                         }
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.5.5-ff07d548.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.5.7-da2a22c3.tar.gz",
                             "type": "tar",
-                            "sha256": "6767651e4e5b34acaa6c53079d66a9047acb74e80fd25f570bf63da87d0ce863",
-                            "bin": "geth-linux-386-1.5.5-ff07d548/geth"
+                            "sha256": "bb068606991eb17cdd971d1635ac0624bbcf5f981d366e5ffc478f30390dc143",
+                            "bin": "geth-linux-386-1.5.7-da2a22c3/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.7" ]
                             }
                         }
                     }
@@ -39,16 +39,16 @@
                 "mac": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.5.5-ff07d548.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.5.7-da2a22c3.tar.gz",
                             "type": "tar",
-                            "sha256": "a5b3ae5b7e9d91a0ca42ca24b079631578cdccce036cc5b1f0035cd0d9706b53",
-                            "bin": "geth-darwin-amd64-1.5.5-ff07d548/geth"
+                            "sha256": "6f58c785bbe2b4f9a6e374a71e14d9e151d5b687e7f50d58c1eb0371209a65f9",
+                            "bin": "geth-darwin-amd64-1.5.7-da2a22c3/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.7" ]
                             }
                         }
                     }
@@ -56,31 +56,31 @@
                 "win": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-amd64-1.5.5-ff07d548-mist-fix.zip",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.5.7-da2a22c3.zip",
                             "type": "zip",
-                            "sha256": "6b9e65ccac8a07535fbfd003662cdd4f69289f93947689c715d10c6486e703d7",
-                            "bin": "geth-windows-amd64-1.5.5-ff07d548\\geth.exe"
+                            "sha256": "d1643c2b12ccf1dabbd34c545d78fc65081be6eebf8bed4a3a2164d0c45eaecf",
+                            "bin": "geth-windows-amd64-1.5.7-da2a22c3\\geth.exe"
                         },
                         "bin": "geth.exe",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.7" ]
                             }
                         }
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-386-1.5.5-ff07d548-mist-fix.zip",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.5.7-da2a22c3.zip",
                             "type": "zip",
-                            "sha256": "74ef8372ae7748c1016a8fcfe2d49574b52a2780913081cf0184fb197f26f01c",
-                            "bin": "geth-windows-386-1.5.5-ff07d548\\geth.exe"
+                            "sha256": "5e25e1056d512cca6e0ff87b1a3172656e556d2fa92f174db2c3f5a0b123faca",
+                            "bin": "geth-windows-386-1.5.7-da2a22c3\\geth.exe"
                         },
                         "bin": "geth.exe",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.5" ]
+                                "output": [ "Geth", "1.5.7" ]
                             }
                         }
                     }

--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -56,9 +56,9 @@
                 "win": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.5.7-da2a22c3-mist-fix.zip",
+                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-amd64-1.5.7-da2a22c3-mist-fix.zip",
                             "type": "zip",
-                            "sha256": "d1643c2b12ccf1dabbd34c545d78fc65081be6eebf8bed4a3a2164d0c45eaecf",
+                            "sha256": "d9677f282f9570de6f11c6c5f4e2163043f035c446c723a64967635834d6e5c0",
                             "bin": "geth-windows-amd64-1.5.7-da2a22c3\\geth.exe"
                         },
                         "bin": "geth.exe",
@@ -71,9 +71,9 @@
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.5.7-da2a22c3-mist-fix.zip",
+                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-386-1.5.7-da2a22c3-mist-fix.zip",
                             "type": "zip",
-                            "sha256": "5e25e1056d512cca6e0ff87b1a3172656e556d2fa92f174db2c3f5a0b123faca",
+                            "sha256": "634b96223345238a489e4b35365cbcae894e9b74e6e0a499ec33ad42223b6af3",
                             "bin": "geth-windows-386-1.5.7-da2a22c3\\geth.exe"
                         },
                         "bin": "geth.exe",

--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -56,7 +56,7 @@
                 "win": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.5.7-da2a22c3.zip",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.5.7-da2a22c3-mist-fix.zip",
                             "type": "zip",
                             "sha256": "d1643c2b12ccf1dabbd34c545d78fc65081be6eebf8bed4a3a2164d0c45eaecf",
                             "bin": "geth-windows-amd64-1.5.7-da2a22c3\\geth.exe"
@@ -71,7 +71,7 @@
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.5.7-da2a22c3.zip",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.5.7-da2a22c3-mist-fix.zip",
                             "type": "zip",
                             "sha256": "5e25e1056d512cca6e0ff87b1a3172656e556d2fa92f174db2c3f5a0b123faca",
                             "bin": "geth-windows-386-1.5.7-da2a22c3\\geth.exe"


### PR DESCRIPTION
### Tested:
---
- [x] macOS
- [x] linux32
- [x] linux64
- [ ] win32
- [ ] win64
---
- [x] stability
- [x] sending