### PR TITLE
add hash and queries to breadcrumb

### DIFF
--- a/interface/client/lib/helpers/helperFunctions.js
+++ b/interface/client/lib/helpers/helperFunctions.js
@@ -116,8 +116,13 @@ Helpers.generateBreadcrumb = function (url) {
     filteredUrl = {
         protocol: Blaze._escape(url.protocol),
         host: Blaze._escape(url.host),
-        pathname: Blaze._escape(url.pathname)
+        pathname: Blaze._escape(url.pathname),
+        search: Blaze._escape(url.search),
+        hash: Blaze._escape(url.hash)
     };
+
+    filteredUrl.pathname += filteredUrl.search.replace(/\?/g, '/');
+    filteredUrl.pathname += filteredUrl.hash.replace(/#/g, '/');
 
     pathname = _.reject(filteredUrl.pathname.replace(/\/$/g, '').split('/'), function (el) {
         return el === '';


### PR DESCRIPTION
Makes # and ? being treated as the same on the breadcrumbs.

<img width="657" alt="screen shot 2017-01-16 at 11 26 02" src="https://cloud.githubusercontent.com/assets/112898/21985379/7b2f43f8-dbe1-11e6-9860-d923fa4ee532.png">

<img width="553" alt="screen shot 2017-01-16 at 11 26 09" src="https://cloud.githubusercontent.com/assets/112898/21985382/7e4d50c0-dbe1-11e6-8525-523b5bee5c6b.png">
