### PR TITLE
[travis] various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,12 @@ matrix:
 
     # MAC
     - os: osx
-      osx_image: xcode8  # currently macOS 10.11 (>= xcode8.1) doesn't support electron-builder codesigning (https://github.com/electron-userland/electron-builder/issues/820#issuecomment-267777060)
+      osx_image: xcode8  # currently xcode8.1+ doesn't support electron-builder macOS code-signing (https://github.com/electron-userland/electron-builder/issues/820#issuecomment-267777060)
       node_js: 6
       env:
           - GULP_PLATFORM=mac
       before_install:
-          - npm install -g yarn  # macOS xcode8 image doesn't natively support yarn
+          - npm install -g yarn  # macOS xcode8 image doesn't natively support yarn yet
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - yarn
 
 script:
-  - if [[ $TRAVIS_BRANCH = "develop" ]]; then unset CSC_LINK CSC_KEY_PASSWORD; fi  # disable macOS code-signing (production certificate) on develop branch
+  - if [[ $TRAVIS_BRANCH != "master" ]]; then unset CSC_LINK CSC_KEY_PASSWORD; fi  # disable macOS code-signing (production certificate) on develop branch
   - travis_wait 60 gulp mist --platform $GULP_PLATFORM
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 branches:
   only:
     - develop
+    - master
 
 matrix:
   include:
@@ -65,6 +66,10 @@ install:
   - yarn
 
 script:
+  - 'if [ "$TRAVIS_BRANCH" = "develop" ]; then
+        unset CSC_KEY_PASSWORD
+        unset CSC_LINK
+    fi'  # no macOS code-signing (production certificate) on develop branch
   - travis_wait 60 gulp mist --platform $GULP_PLATFORM
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ matrix:
     # WINDOWS cross-built from linux
     - os: linux
       dist: trusty
+      node_js: 6
       env:
           - GULP_PLATFORM=win
-      node_js: 6
       addons:
         apt:
           packages:
@@ -35,9 +35,9 @@ matrix:
     # LINUX
     - os: linux
       dist: trusty
+      node_js: 6
       env:
           - GULP_PLATFORM=linux
-      node_js: 6
       addons:
         apt:
           packages:
@@ -50,12 +50,11 @@ matrix:
     # MAC
     - os: osx
       osx_image: xcode8  # currently macOS 10.11 (>= xcode8.1) doesn't support electron-builder codesigning (https://github.com/electron-userland/electron-builder/issues/820#issuecomment-267777060)
+      node_js: 6
       env:
           - GULP_PLATFORM=mac
-      node_js: 6
       before_install:
-        - brew update
-        - brew install gnu-tar libicns graphicsmagick xz
+          - npm install -g yarn  # macOS xcode8 image doesn't natively support yarn
 
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 branches:
   only:
     - develop
-    - travis
 
 matrix:
   include:
@@ -49,26 +48,20 @@ matrix:
 
     # MAC
     - os: osx
-      osx_image: xcode8.1
+      osx_image: xcode8  # currently macOS 10.11 (>= xcode8.1) doesn't support electron-builder codesigning (https://github.com/electron-userland/electron-builder/issues/820#issuecomment-267777060)
       env:
           - GULP_PLATFORM=mac
       node_js: 6
       before_install:
         - brew update
         - brew install gnu-tar libicns graphicsmagick xz
-        - npm install -g gulp yarn
 
 cache:
   yarn: true
-  directories:
-    - node_modules
-    - app/node_modules
-    - $HOME/.electron
-    - $HOME/.cache
 
 install:
   - PATH=$PATH:$HOME/.meteor && curl -L https://raw.githubusercontent.com/arunoda/travis-ci-meteor-packages/master/configure.sh | /bin/sh
-  - npm install -g meteor-build-client electron@1.3.5
+  - yarn global add gulp-cli meteor-build-client electron@1.3.5
   - yarn
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,7 @@ install:
   - yarn
 
 script:
-  - 'if [ "$TRAVIS_BRANCH" = "develop" ]; then
-        unset CSC_KEY_PASSWORD
-        unset CSC_LINK
-    fi'  # no macOS code-signing (production certificate) on develop branch
+  - if [[ $TRAVIS_BRANCH = "develop" ]]; then unset CSC_LINK CSC_KEY_PASSWORD; fi  # disable macOS code-signing (production certificate) on develop branch
   - travis_wait 60 gulp mist --platform $GULP_PLATFORM
 
 after_success:


### PR DESCRIPTION
- mac: use `xcode8` instead of `xcode8.1` build image (fixes macOS code-signing [issue](https://github.com/electron-userland/electron-builder/issues/820#issuecomment-267777060))
- disable macOS code-signing on `develop`
- enable build (and macOS code-signing) on `master`
- remove `travis` branch (used for PR testing)
- remove unnecessary linux dependencies on mac build 
- move `npm install -g gulp-cli` to global; rectify `gulp` to `gulp-cli`; use yarn instead of npm
- cleanup caches:
  - remove duplicate `node_module` caches (`cache: yarn: true` is already defined and more efficient)
  - remove electron (binary) cache (travis caches those internally more efficiently)