### PR TITLE
Allow for operators while parsing 'mist.solidity.version'

### DIFF
--- a/modules/preloader/include/mistAPI.js
+++ b/modules/preloader/include/mistAPI.js
@@ -57,7 +57,7 @@ module.exports = () => {
             ipcRenderer.send('mistAPI_requestAccount');
         },
         solidity: {
-            version: packageJson.dependencies.solc,
+            version: String(packageJson.dependencies.solc).match(/\d+.\d+.\d+/)[0],
         },
         sounds: {
             bip: function playSound() {

--- a/modules/preloader/include/mistAPI.js
+++ b/modules/preloader/include/mistAPI.js
@@ -57,7 +57,7 @@ module.exports = () => {
             ipcRenderer.send('mistAPI_requestAccount');
         },
         solidity: {
-            version: String(packageJson.dependencies.solc).match(/\d+.\d+.\d+/)[0],
+            version: String(packageJson.dependencies.solc).match(/\d+\.\d+\.\d+/)[0],
         },
         sounds: {
             bip: function playSound() {


### PR DESCRIPTION
When parsing, omit operators in package.json like:
 - `^0.4.6`
 - `=0.4.6`
 - `>=^0.4.6`
 - `>=0.4.6 <0.4.9`

(see https://yarnpkg.com/en/docs/dependency-versions)