### PR TITLE
Update geth to 1.5.5 (#1520) (#1522)

### DIFF
--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -2,36 +2,36 @@
 {
     "clients": {
         "Geth": {
-            "version": "1.5.3",
+            "version": "1.5.5",
             "platforms": {
                 "linux": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.3-978737f5.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.5-ff07d548.tar.gz",
                             "type": "tar",
-                            "sha256": "7f1de3b66176111864571d66917ec885f0e789b140e1fca01bf2296cbcb13f57",
-                            "bin": "geth-linux-amd64-1.5.3-978737f5/geth"
+                            "sha256": "4f36d6df25c37eb33829407d8bf2cea209cc412b3443319e2430db18581c7c01",
+                            "bin": "geth-linux-amd64-1.5.5-ff07d548/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.3" ]
+                                "output": [ "Geth", "1.5.5" ]
                             }
                         }
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.5.3-978737f5.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.5.5-ff07d548.tar.gz",
                             "type": "tar",
-                            "sha256": "527785d2d21655fb5756390ce06188961929856295f29811afe188aa5585880b",
-                            "bin": "geth-linux-386-1.5.3-978737f5/geth"
+                            "sha256": "6767651e4e5b34acaa6c53079d66a9047acb74e80fd25f570bf63da87d0ce863",
+                            "bin": "geth-linux-386-1.5.5-ff07d548/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.3" ]
+                                "output": [ "Geth", "1.5.5" ]
                             }
                         }
                     }
@@ -39,16 +39,16 @@
                 "mac": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.5.3-978737f5.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.5.5-ff07d548.tar.gz",
                             "type": "tar",
-                            "sha256": "dca175529d1d626d7ccb7dafab4374a39d715dc524734b09e5c4ebbb68615ffb",
-                            "bin": "geth-darwin-amd64-1.5.3-978737f5/geth"
+                            "sha256": "a5b3ae5b7e9d91a0ca42ca24b079631578cdccce036cc5b1f0035cd0d9706b53",
+                            "bin": "geth-darwin-amd64-1.5.5-ff07d548/geth"
                         },
                         "bin": "geth",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.3" ]
+                                "output": [ "Geth", "1.5.5" ]
                             }
                         }
                     }
@@ -56,31 +56,31 @@
                 "win": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-amd64-1.5.3-978737f5-mist-fix.zip",
+                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-amd64-1.5.5-ff07d548-mist-fix.zip",
                             "type": "zip",
-                            "sha256": "329caa90b5e02f71300b217c3a93a777c6ef09ae38d7be4f2cd5127ddbaed0e1",
-                            "bin": "geth-windows-amd64-1.5.3-978737f5\\geth.exe"
+                            "sha256": "6b9e65ccac8a07535fbfd003662cdd4f69289f93947689c715d10c6486e703d7",
+                            "bin": "geth-windows-amd64-1.5.5-ff07d548\\geth.exe"
                         },
                         "bin": "geth.exe",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.3" ]
+                                "output": [ "Geth", "1.5.5" ]
                             }
                         }
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-386-1.5.3-978737f5-mist-fix.zip",
+                            "url": "https://gethstore.blob.core.windows.net/mist/geth-windows-386-1.5.5-ff07d548-mist-fix.zip",
                             "type": "zip",
-                            "sha256": "637447797ed362a409d9e8e5b12bee1a56009faa8a98c20dab4af77f04527b2e",
-                            "bin": "geth-windows-386-1.5.3-978737f5\\geth.exe"
+                            "sha256": "74ef8372ae7748c1016a8fcfe2d49574b52a2780913081cf0184fb197f26f01c",
+                            "bin": "geth-windows-386-1.5.5-ff07d548\\geth.exe"
                         },
                         "bin": "geth.exe",
                         "commands": {
                             "sanity": {
                                 "args": ["version"],
-                                "output": [ "Geth", "1.5.3" ]
+                                "output": [ "Geth", "1.5.5" ]
                             }
                         }
                     }

--- a/modules/clientBinaryManager.js
+++ b/modules/clientBinaryManager.js
@@ -12,8 +12,11 @@ const EventEmitter = require('events').EventEmitter;
 const log = require('./utils/logger').create('ClientBinaryManager');
 
 
+// should be       'https://raw.githubusercontent.com/ethereum/mist/master/clientBinaries.json'
+const BINARY_URL = 'https://raw.githubusercontent.com/ethereum/mist/master/clientBinaries.json';
+
 const ALLOWED_DOWNLOAD_URLS_REGEX =
-    /^https:\/\/(?:(?:[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?\.)?ethereum\.org\/|gethstore\.blob\.core\.windows\.net\/|bintray\.com\/artifact\/download\/karalabe\/ethereum\/)(?:.+)/;  // eslint-disable-line max-len
+    /^https:\/\/(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)?ethereum\.org\/|gethstore\.blob\.core\.windows\.net\/|bintray\.com\/artifact\/download\/karalabe\/ethereum\/)(?:.+)/;  // eslint-disable-line max-len
 
 class Manager extends EventEmitter {
     constructor() {
@@ -50,12 +53,12 @@ class Manager extends EventEmitter {
         let binariesDownloaded = false;
         let nodeInfo;
 
-        log.info('Checking for new client binaries config...');
+        log.info(`Checking for new client binaries config from: ${BINARY_URL}`);
 
         this._emit('loadConfig', 'Fetching remote client config');
 
         // fetch config
-        return got('https://raw.githubusercontent.com/ethereum/mist/master/clientBinaries.json', {
+        return got(BINARY_URL, {
             timeout: 3000,
             json: true,
         })

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -323,7 +323,7 @@ class EthereumNode extends EventEmitter {
         else 
             throw new Error(`Node "${nodeType}" binPath is not available.`);
 
-        log.debug(`Start node using ${binPath}`);
+        log.info(`Start node using ${binPath}`);
 
         return new Q((resolve, reject) => {
             this.__startProcess(nodeType, network, binPath)


### PR DESCRIPTION
* updated solc again

* updated solc to 0.4.6

* Update geth to 1.5.5 (#1520)

* Update geth to 1.5.5

* corrected windows zip's internal paths

* changed sanity check

* made node starting better

* also log path from which to fetch

* show fetching origin URL

* fix ESLint errors

* removed -stable