### PR TITLE
Add gulp task 'update-nodes'

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
     "mocha": "^3.2.0",
     "optimist": "^0.6.1",
     "run-sequence": "^1.2.1",
+    "semver-compare": "^1.0.0",
     "shelljs": "^0.7.6",
-    "spectron": "3.3.0"
+    "spectron": "3.3.0",
+    "xml2js": "^0.4.17"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3508,6 +3508,10 @@ sanitize-filename@^1.6.1:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
+sax@>=0.6.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
 secp256k1@^3.0.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.2.2.tgz#2103620789ca2c9b79650cdf8cfc9c542be36597"
@@ -3525,6 +3529,10 @@ seek-bzip@^1.0.3:
   resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
   dependencies:
     commander "~2.8.1"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -4327,9 +4335,22 @@ xdg-basedir@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
+xml2js@^0.4.17:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "^4.1.0"
+
 xmlbuilder@8.2.2:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+
+xmlbuilder@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
+  dependencies:
+    lodash "^4.0.0"
 
 xmldom@0.1.x:
   version "0.1.27"


### PR DESCRIPTION
This gulp-task will:
1. query the latest geth version from its github releases
1. compare its version to 'clientBinaries.json' and if newer will
1. query github for the commit hash and azure for the md5 checksums
1. update 'clientBinaries.json' accordingly

Its execution takes:
- ~100ms if no update available
- 5-10s if update is available