### PR TITLE
enable translations on splash screen

### DIFF
--- a/interface/client/appStart.js
+++ b/interface/client/appStart.js
@@ -1,9 +1,3 @@
-
-
-// STOP here if not MAIN WINDOW
-if(location.hash)
-    return;
-
 /**
 The init function of Mist
 
@@ -17,7 +11,7 @@ mistInit = function(){
     Tabs.onceSynced.then(function() {
         if (0 <= location.search.indexOf('reset-tabs')) {
             console.info('Resetting UI tabs');
-            
+
             Tabs.remove({});
         }
 
@@ -56,13 +50,15 @@ mistInit = function(){
 Meteor.startup(function(){
     console.info('Meteor starting up...');
 
-    EthAccounts.init();
-    mistInit();
+    if (!location.hash) {
+        EthAccounts.init();
+        mistInit();
+    }
 
     console.debug('Setting language');
 
     // SET default language
-    if(Cookie.get('TAPi18next')) {        
+    if(Cookie.get('TAPi18next')) {
         TAPi18n.setLanguage(Cookie.get('TAPi18next'));
     } else {
         var userLang = navigator.language || navigator.userLanguage,
@@ -87,4 +83,3 @@ Meteor.startup(function(){
         }
     });
 });
-


### PR DESCRIPTION
Also this PR removes the global return, which causes some trouble with ESLint (see [here](https://github.com/eslint/eslint/issues/2339#issuecomment-106132519) and [here](https://github.com/babel/babel/issues/1298#issuecomment-94305573))

From what I gathered `location.hash` will resolve to `''` in the main window and `'#splashScreen_mist'`/`'#splashScreen_wallet'` on the splash screen.
As I couldn't trigger or find any other string (only [main.js#L243](https://github.com/ethereum/mist/blob/luclu_update-splash-screen-lang/main.js#L243)) I chose `!location.hash` as the condition.