### PR TITLE
[ESLint] exclude auto-generated 'signatures.js'

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,5 +20,4 @@ ratings:  ## enables GPA rating
    - "**.js"
 
 exclude_paths:
-- "interface/client/lib/signatures.js"
 - "tests/"

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+interface/client/lib/signatures.js


### PR DESCRIPTION
This file causes nearly 10000 linter errors as the JSON object uses double-quotes instead of single-quotes.
Unfortunately this can't be changed as option of `JSON.stringify()`, thus this simpler solution.

*Note: the code climate linter did already exclude it via the config file, the change will apply to code climate as well as any other eslint tool like editor plugins*