### PR TITLE
fix #1649 (add lokijs save-throttling)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "i18next": "^6.1.1",
     "log-rotate": "^0.2.7",
     "log4js": "^1.1.0",
-    "lokijs": "^1.4.2",
+    "lokijs": "^1.4.3",
     "minimongo-standalone": "^1.1.0-3",
     "numeral": "^2.0.4",
     "oboe": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,7 +225,7 @@ babel-runtime@^5.8.25:
   dependencies:
     core-js "^1.0.0"
 
-babel-runtime@^6.22.0, babel-runtime@^6.9.2:
+babel-runtime@^6.9.2:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
   dependencies:
@@ -2627,9 +2627,9 @@ log4js@^1.1.0:
     semver "^5.3.0"
     streamroller "^0.2.1"
 
-lokijs@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/lokijs/-/lokijs-1.4.2.tgz#0f176380f9930d117946fc7c15ccb4ca001ddb4a"
+lokijs@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/lokijs/-/lokijs-1.4.3.tgz#f2a47ba8d6991c92d6da6a5b35be79b674453abb"
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
fixes https://github.com/ethereum/mist/issues/1649

Upstream issue: https://github.com/techfort/LokiJS/issues/526#issuecomment-272428421

This issue occured when lokijs's db save procedures overlapped.
Version `1.4.3` added some protection by default:
https://github.com/techfort/LokiJS/wiki/LokiJS-persistence-and-adapters#save-throttling-and-persistence-contention-management