### PR TITLE
[spectron] increase timeout for '"file" protocol should be disallowed on browser bar'

### DIFF
--- a/tests/mist/basic.test.js
+++ b/tests/mist/basic.test.js
@@ -155,7 +155,7 @@ test['"file" protocol should be disallowed on browser bar'] = function* () { // 
     const filePath = 'file://' + path.join(__dirname, '..', 'fixtures', 'index.html');
 
     yield this.navigateTo(filePath);
-    yield Q.delay(1500);
+    yield Q.delay(2500);
     const browserBarText = yield this.getBrowserBarText();
     browserBarText.should.match(/errorPages ▸ 400.html$/);
 };


### PR DESCRIPTION
As travis did fail to run this test on the first try on several PRs due to timing out.