### PR TITLE
[electron-builder] fix 'node_modules' copy

### DIFF
--- a/gulpTasks/building.js
+++ b/gulpTasks/building.js
@@ -25,7 +25,9 @@ gulp.task('clean-dist', (cb) => {
 
 gulp.task('copy-app-source-files', () => {
     return gulp.src([
-        'node_modules/**',
+        'node_modules/**/*',
+        '!node_modules/electron/',
+        '!node_modules/electron/**/*',
         './main.js',
         './clientBinaries.json',
         './modules/**',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,9 +11,18 @@ const gulp = require('gulp');
 const minimist = require('minimist');
 const runSeq = require('run-sequence');
 
+// available crossplatform builds
+let platforms;
+if (process.platform === 'darwin') {
+    platforms = ['mac', 'linux', 'win'];
+} else if (process.platform === 'win32') {
+    platforms = ['win'];
+} else {
+    platforms = ['linux', 'win'];
+}
+
 // parse commandline arguments
 const args = process.argv.slice(2);
-const platforms = (process.platform === 'darwin') ? ['mac', 'linux', 'win'] : ['linux', 'win'];
 const options = minimist(args, {
     string: ['walletSource', 'test'],
     boolean: _.flatten(['wallet', platforms]),


### PR DESCRIPTION
copying errored due to symlinks in unnecessarily copied 'electron' devDep package