### PR TITLE
[electron-builder] fix 'node_modules' copy (#2196)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,11 +68,17 @@ install:
   - yarn
 
 script:
-  - if [[ $TRAVIS_BRANCH != "master" ]]; then unset CSC_LINK CSC_KEY_PASSWORD; fi  # disable macOS code-signing (production certificate) on develop branch
+  # disable macOS code-signing (production certificate) on develop branch
+  - if [[ $TRAVIS_BRANCH != "master" ]]; then unset CSC_LINK CSC_KEY_PASSWORD; fi
+  # windows code-signing on master branch
+  - if [[ $GULP_PLATFORM == "win" && $TRAVIS_BRANCH == "master" ]]; then export CSC_LINK=$CSC_WIN_LINK && CSC_KEY_PASSWORD=$CSC_WIN_KEY_PASSWORD; fi
+  # build mist
   - if [[ $GULP_PLATFORM == "mac" ]]; then travis_wait 60 gulp --$GULP_PLATFORM; fi  # increase timeout for slower mac builds
   - if [[ $GULP_PLATFORM != "mac" ]]; then gulp --$GULP_PLATFORM; fi
-  - if [[ $TRAVIS_BRANCH == "master" ]]; then travis_wait 60 gulp --wallet --$GULP_PLATFORM; fi  # also build wallet if on master branch
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; sleep 3; fi  # prepare for integration testing
+  # build wallet if on master branch
+  - if [[ $TRAVIS_BRANCH == "master" ]]; then travis_wait 60 gulp --wallet --$GULP_PLATFORM; fi
+  # prepare and run integration tests
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; sleep 3; fi
   - if [[ $GULP_PLATFORM != "win" ]]; then gulp test; fi
 
 after_success:

--- a/gulpTasks/building.js
+++ b/gulpTasks/building.js
@@ -25,7 +25,9 @@ gulp.task('clean-dist', (cb) => {
 
 gulp.task('copy-app-source-files', () => {
     return gulp.src([
-        'node_modules/**',
+        'node_modules/**/*',
+        '!node_modules/electron/',
+        '!node_modules/electron/**/*',
         './main.js',
         './clientBinaries.json',
         './modules/**',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,9 +11,18 @@ const gulp = require('gulp');
 const minimist = require('minimist');
 const runSeq = require('run-sequence');
 
+// available crossplatform builds
+let platforms;
+if (process.platform === 'darwin') {
+    platforms = ['mac', 'linux', 'win'];
+} else if (process.platform === 'win32') {
+    platforms = ['win'];
+} else {
+    platforms = ['linux', 'win'];
+}
+
 // parse commandline arguments
 const args = process.argv.slice(2);
-const platforms = (process.platform === 'darwin') ? ['mac', 'linux', 'win'] : ['linux', 'win'];
 const options = minimist(args, {
     string: ['walletSource', 'test'],
     boolean: _.flatten(['wallet', platforms]),


### PR DESCRIPTION
copying errored due to symlinks in unnecessary 'electron' devDep package