### PR TITLE
[travis] update github publish

### DIFF
--- a/gulpTasks/building.js
+++ b/gulpTasks/building.js
@@ -162,6 +162,7 @@ gulp.task('build-dist', (cb) => {
     builder.build({
         targets: builder.createTargets(targets, null, 'all'),
         projectDir: path.join(__dirname, `../dist_${type}`, 'app'),
+        publish: 'never',
         config: {
             afterPack(params) {
                 return Q.try(() => {

--- a/gulpTasks/building.js
+++ b/gulpTasks/building.js
@@ -133,17 +133,18 @@ gulp.task('build-dist', (cb) => {
             dmg: {
                 background: '../build/dmg-background.jpg',
                 iconSize: 128,
-                contents: [{
-                    x: 441,
-                    y: 448,
-                    type: 'link',
-                    path: '/Applications'
-                },
-                {
-                    x: 441,
-                    y: 142,
-                    type: 'file'
-                }
+                contents: [
+                    {
+                        x: 441,
+                        y: 448,
+                        type: 'link',
+                        path: '/Applications'
+                    },
+                    {
+                        x: 441,
+                        y: 142,
+                        type: 'file'
+                    }
                 ]
             }
         }


### PR DESCRIPTION
As `electron-builder` recently got its own github release uploader, it seems to interfere with our github release uploader, in that during the build it messes with the drafts and change their release tags.

Although the integrated release uploader might be handy it doesn't allow for a convenient way to append checksums to the draft's text yet.

This PR will disable the new system.
