### PR TITLE
[travis] fix github uploader (github API behaviour changed)

### DIFF
--- a/gulpTasks/publishing.js
+++ b/gulpTasks/publishing.js
@@ -91,6 +91,7 @@ gulp.task('upload-binaries', (cb) => {
                 if (draft.body && checksums) {
                     got.patch(`https://api.github.com/repos/ethereum/mist/releases/${draft.id}?access_token=${GITHUB_TOKEN}`, {
                         body: JSON.stringify({
+                            tag_name: `v${version}`,
                             body: `${draft.body}\n\n## Checksums\n\`\`\`\n${checksums.join('')}\`\`\``
                         })
                     });

--- a/tests/mist/basic.test.js
+++ b/tests/mist/basic.test.js
@@ -32,7 +32,7 @@ test['Browser bar should not render script tags on breadcrumb view'] = function*
         return client.getText('.url-breadcrumb').then((e) => {
             return /404\.html$/.test(e);
         });
-    }, 5000, 'expected breadcrumb to render as HTML encoded');
+    }, 8000, 'expected breadcrumb to render as HTML encoded');
 
     should.exist(yield this.getUiElement('form.url'));
     should.not.exist(yield this.getUiElement('form.url script'));
@@ -60,7 +60,7 @@ test['Browser bar should not render script tags in disguise (2) on breadcrumb vi
         return client.getText('.url-breadcrumb').then((e) => {
             return /404\.html$/.test(e);
         });
-    }, 5000, 'expected breadcrumb to render as HTML encoded');
+    }, 8000, 'expected breadcrumb to render as HTML encoded');
 
     should.exist(yield this.getUiElement('form.url'));
     should.not.exist(yield this.getUiElement('form.url svg'));


### PR DESCRIPTION
Apparently Github's API now does require to re-set the `tag_name` when patching a release drafts text.

Funnily this is not necessary for my fork branch (see https://travis-ci.org/luclu/mist/jobs/229764306) but the main repo.