### PR TITLE
Update Readme with latest stable Electron version to avoid exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ To run mist in development you need:
 - [Node.js](https://nodejs.org) `v6.x` (use the prefered installation method for your OS)
 - [Meteor](https://www.meteor.com/install) javascript app framework
 - [Yarn](https://yarnpkg.com/) package manager
-- [Electron](http://electron.atom.io/) `v1.3.13` cross platform desktop app framework
+- [Electron](http://electron.atom.io/) `v1.6.10` cross platform desktop app framework
 - [Gulp](http://gulpjs.com/) build and automation system
 
 Install the later ones via:
 
     $ curl https://install.meteor.com/ | sh
     $ curl -o- -L https://yarnpkg.com/install.sh | bash
-    $ yarn global add electron@1.3.13
+    $ yarn global add electron@1.6.10
     $ yarn global add gulp
 
 ### Initialisation


### PR DESCRIPTION
**What do you run?** 
I ran the following initially to install the development version from the command line and initialise Mist:
```
curl -o- -L https://yarnpkg.com/install.sh | bash
brew upgrade yarn
yarn global add electron@1.3.13
yarn global add gulp
git clone https://github.com/ethereum/mist.git
cd mist
yarn
cd interface && meteor --no-release-check
electron . --loglevel debug
```
But running the `electron` command caused the following error:

```
$ electron --version
fs.js:640
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '~/.config/yarn/global/node_modules/electron/path.txt'
    at Error (native)
    at Object.fs.openSync (fs.js:640:18)
    at Object.fs.readFileSync (fs.js:508:33)
    at Object.<anonymous> (~/.config/yarn/global/node_modules/electron/index.js:4:42)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
```

So then I updated to the latest stable version of Meteor 1.5 (as only 1.4.2.3 was installed) with `meteor update --release 1.5`, but I still encountered the exception.

So then I updated Electron to the latest version 1.6.10 (instead of 1.3.13 as currently suggested in the Readme) with `yarn global add electron@1.6.10`, and this fixed the issue.

**Which version do you used?**
Mist 0.8.10
Electron 1.3.13 (previously) but now Electron 1.6.10 (fixed the issue)
Node 6.6
Meteor v1.5
yarn v0.24.6
gulp v3.9.1

**What OS you're on?**
macOS El Capitan 10.11.5