### PR TITLE
Removing redundant userAgent string

### DIFF
--- a/interface/client/lib/helpers/templateHelpers.js
+++ b/interface/client/lib/helpers/templateHelpers.js
@@ -77,15 +77,6 @@ Template.registerHelper('appIconPath', function () {
 });
 
 /**
-Get the current user agent
-
-@method (useragent)
-**/
-Template.registerHelper('useragent', function () {
-    return navigator.userAgent + ' Ethereum ' + (window.mistMode === 'mist' ? 'Mist' : 'Wallet');
-});
-
-/**
 Get all accounts
 
 @method (accounts)
@@ -177,5 +168,3 @@ Formats a number.
 @return {String} The formatted number
 **/
 Template.registerHelper('formatBalance', Helpers.formatBalance);
-
-

--- a/interface/client/templates/views/webview.html
+++ b/interface/client/templates/views/webview.html
@@ -1,9 +1,9 @@
 <template name="views_webview">
     <div class="webview {{isVisible}} {{#if appBar}}app-bar-{{appBar}}{{/if}}">
         {{#if $eq _id "tests"}}
-            <webview src="file://{{dirname}}/tests/mocha-in-browser/runner.html" useragent="{{useragent}}" data-id="{{_id}}" preload="{{preloaderFile}}" autosize="on"></webview>
+            <webview src="file://{{dirname}}/tests/mocha-in-browser/runner.html" data-id="{{_id}}" preload="{{preloaderFile}}" autosize="on"></webview>
         {{else}}
-            <webview src="{{checkedUrl}}" useragent="{{useragent}}" data-id="{{_id}}" preload="{{preloaderFile}}" autosize="on"></webview>
+            <webview src="{{checkedUrl}}" data-id="{{_id}}" preload="{{preloaderFile}}" autosize="on"></webview>
         {{/if}}
     </div>
 </template>


### PR DESCRIPTION
The user agent fragment we append to the original UA is redundant, and does not follow the "vendor/version" pattern. This PR aims to fix this. 

Mist
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) **Mist/0.8.10** Chrome/52.0.2743.82 Electron/1.3.13 Safari/537.36 ~Ethereum Mist~"

Wallet
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) **EthereumWallet/0.8.10** Chrome/52.0.2743.82 Electron/1.3.13 Safari/537.36 ~Ethereum Wallet~"

