### PR TITLE
Add bzz and .eth to urls

### DIFF
--- a/interface/client/lib/helpers/helperFunctions.js
+++ b/interface/client/lib/helpers/helperFunctions.js
@@ -79,22 +79,21 @@ Format Urls, e.g add a default protocol if on is missing.
 @param {String} url
 **/
 Helpers.formatUrl = function (url) {
+    if (!url) return;
+
     // add http:// if no protocol is present
-    if (url && url.length === 64 && !!url.match(/^[0-9a-f]+$/)) {
+    if (url.length === 64 && !!url.match(/^[0-9a-f]+$/)) {
         // if the url looks like a hash, add bzz
         url = 'bzz://' + url;
-    } else if (url && url.indexOf('://') === -1) {
-        console.log('formatURL', url, !!url.match(/[\./#]/i))
-        if (!url.match(/[\./#]/i)) {
-            // if it doesn't have a protocol or a TLD
-            url = 'bzz://' + url + '.eth';
-        } else if (!!url.match(/^[^/]*\.eth/i)) {
-            // doesn't have a protocol but has .eth as TLD
-            url = 'bzz://' + url;
-        } else {
-            // if it doesn't have a protocol
-            url = 'http://' + url;
-        }
+    } else if (!!url.match(/^([a-z]*:\/\/)?[^/]*\.eth/i)) {
+        // if uses .eth as a TLD
+        url = 'bzz://' + url.replace(/^([a-z]*:\/\/)?/i, '');
+    } else if (!!url.match(/^[^\.\/]*$/i)) {
+        // doesn't have a protocol nor a TLD
+        url = 'bzz://' + url + '.eth';
+    } else if (url.indexOf('://') === -1) {
+        // if it doesn't have a protocol
+        url = 'http://' + url;
     }
 
     return url;

--- a/interface/client/lib/helpers/helperFunctions.js
+++ b/interface/client/lib/helpers/helperFunctions.js
@@ -85,7 +85,7 @@ Helpers.formatUrl = function (url) {
     if (url.length === 64 && !!url.match(/^[0-9a-f]+$/)) {
         // if the url looks like a hash, add bzz
         url = 'bzz://' + url;
-    } else if (!!url.match(/^([a-z]*:\/\/)?[^/]*\.eth/i)) {
+    } else if (!!url.match(/^([a-z]*:\/\/)?[^/]*\.eth(\/.*)?$/i)) {
         // if uses .eth as a TLD
         url = 'bzz://' + url.replace(/^([a-z]*:\/\/)?/i, '');
     } else if (!!url.match(/^[^\.\/]*$/i)) {

--- a/interface/client/lib/helpers/helperFunctions.js
+++ b/interface/client/lib/helpers/helperFunctions.js
@@ -84,8 +84,17 @@ Helpers.formatUrl = function (url) {
         // if the url looks like a hash, add bzz
         url = 'bzz://' + url;
     } else if (url && url.indexOf('://') === -1) {
-        // if it doesn't have a protocol
-        url = 'http://' + url;
+        console.log('formatURL', url, !!url.match(/[\./#]/i))
+        if (!url.match(/[\./#]/i)) {
+            // if it doesn't have a protocol or a TLD
+            url = 'bzz://' + url + '.eth';
+        } else if (!!url.match(/^[^/]*\.eth/i)) {
+            // doesn't have a protocol but has .eth as TLD
+            url = 'bzz://' + url;
+        } else {
+            // if it doesn't have a protocol
+            url = 'http://' + url;
+        }
     }
 
     return url;

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -230,6 +230,7 @@ let menuTempl = function (webviews) {
                               }});
                               LocalStore.set('selectedTab', 'browser');
                             `);
+                            console.log('Hash uploaded:', hash);
                         }).catch(e => console.log(e));
                     }
                 }

--- a/tests/mist/basic.test.js
+++ b/tests/mist/basic.test.js
@@ -17,6 +17,7 @@ test['Sanity Check: main window is focused'] = function* () {
 
 test['Browser bar should render urls with separators'] = function* () {
     yield this.navigateTo('http://localhost:8080/page1/page2?param=value#hash');
+    yield Q.delay(500);
     yield this.waitForText('.url-breadcrumb', 'http://localhost:8080 ▸ page1 ▸ page2 ▸ param=value ▸ hash');
 };
 


### PR DESCRIPTION
If the user just types a word on the URL bar, without any protocol or TLD, then default it to bzz://xxxxx.eth