### PR TITLE
Node info breaks on slow IPC connection

### DIFF
--- a/interface/client/appStart.js
+++ b/interface/client/appStart.js
@@ -7,6 +7,13 @@ mistInit = function () {
     console.info('Initialise Mist Interface');
 
     EthBlocks.init();
+    const ethBlocksInterval = setInterval(() => {
+        if (_.isEmpty(EthBlocks.latest)) {
+            EthBlocks.init();
+        } else {
+            clearInterval(ethBlocksInterval);
+        }
+    }, 500);
 
     Tabs.onceSynced.then(function () {
         if (location.search.indexOf('reset-tabs') >= 0) {


### PR DESCRIPTION
Geetings Mist team! 

I'm working on [Mewify](https://github.com/MyEtherWallet/mewify/tree/develop) for MyEtherWallet. It emulates a local Geth IPC connection which allows users to run Mist with our public backend instead of syncing a full node.

I'm having trouble getting Mist to boot up correctly when connected through Mewify -- it seems as if the data provided by `EthBlocks.init()` doesn't get returned, and as a result the node info display remains broken for the life of the application. This occurs whenever there is sufficient latency (as little as 50ms) in the round-trip time from client IPC request to server response.  

AFAICT, Mist will create an IPC socket on boot, and then 'reset' that socket shortly after. The pattern I'm seeing goes like `Mist boot -> IPC connection established -> EthStats.init() -> Mist resets IPC connection -> Mewify attempts to write to a now dead socket`. I believe this isn't normally observed with Geth because the local node is able to fetch & return the required data before the connection is initially cycled. However, initialization would still likely fail if Geth where to hiccup for any reason.

I was able to fix this by inserting an interval in `appStart.js` to confirm `EthStats.init()` completes. On the cases where `EthStats.init` is called more than once, there doesn't seem to be any detriment.

Does this seem like something that could get merged in at some point?

TLDR: Block info breaks when the connected node serves slow responses because initial IPC connections get reset and `EthStats.init()` can't complete.