### PR TITLE
Update copyright year 2016 to 2017 on About page

### DIFF
--- a/interface/client/templates/popupWindows/about.html
+++ b/interface/client/templates/popupWindows/about.html
@@ -10,7 +10,7 @@
                 License {{mist.license}}<br>
                 GitHub <a href="https://github.com/ethereum/mist" target="_blank">github.com/ethereum/mist</a>
             </p>
-            <small>Copyright 2016 Ethereum Foundation</small>
+            <small>Copyright 2017 Ethereum Foundation</small>
         </div>
     </div>
 </template>


### PR DESCRIPTION
Update copyright year `2016` to `2017` on `About Mist` page