### PR TITLE
Light client bindings on Mist/Wallet

### DIFF
--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -1,15 +1,15 @@
 {
     "clients": {
         "Geth": {
-            "version": "1.6.7",
+            "version": "1.7.0",
             "platforms": {
                 "linux": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.6.7-ab5646c5.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.0-6c6c7b2a.tar.gz",
                             "type": "tar",
-                            "md5": "d5331a9ba124778d6d1341baba56ef11",
-                            "bin": "geth-linux-amd64-1.6.7-ab5646c5/geth"
+                            "md5": "9f40a6cd7f8f6de6b3cfd480847f7c38",
+                            "bin": "geth-linux-amd64-1.7.0-6c6c7b2a/geth"
                         },
                         "bin": "geth",
                         "commands": {
@@ -19,17 +19,17 @@
                                 ],
                                 "output": [
                                     "Geth",
-                                    "1.6.7"
+                                    "1.7.0"
                                 ]
                             }
                         }
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.6.7-ab5646c5.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-linux-386-1.7.0-6c6c7b2a.tar.gz",
                             "type": "tar",
-                            "md5": "d9833199b6df5404be6cedc854198e1d",
-                            "bin": "geth-linux-386-1.6.7-ab5646c5/geth"
+                            "md5": "611ae050fe9dbbb90fec1be4e9f6d356",
+                            "bin": "geth-linux-386-1.7.0-6c6c7b2a/geth"
                         },
                         "bin": "geth",
                         "commands": {
@@ -39,7 +39,7 @@
                                 ],
                                 "output": [
                                     "Geth",
-                                    "1.6.7"
+                                    "1.7.0"
                                 ]
                             }
                         }
@@ -48,10 +48,10 @@
                 "mac": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.6.7-ab5646c5.tar.gz",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.7.0-6c6c7b2a.tar.gz",
                             "type": "tar",
-                            "md5": "3da6ebf7255deb74bd46743cb7113b1b",
-                            "bin": "geth-darwin-amd64-1.6.7-ab5646c5/geth"
+                            "md5": "fbd3103db321886e5abf93a4d3f42577",
+                            "bin": "geth-darwin-amd64-1.7.0-6c6c7b2a/geth"
                         },
                         "bin": "geth",
                         "commands": {
@@ -61,7 +61,7 @@
                                 ],
                                 "output": [
                                     "Geth",
-                                    "1.6.7"
+                                    "1.7.0"
                                 ]
                             }
                         }
@@ -70,10 +70,10 @@
                 "win": {
                     "x64": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.6.7-ab5646c5.zip",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.7.0-6c6c7b2a.zip",
                             "type": "zip",
-                            "md5": "6c5d11b0e0d1ca420be2a0d092466c2f",
-                            "bin": "geth-windows-amd64-1.6.7-ab5646c5\\geth.exe"
+                            "md5": "d73d0c3e41263d8cccd72fbabb5cc4d1",
+                            "bin": "geth-windows-amd64-1.7.0-6c6c7b2a\\geth.exe"
                         },
                         "bin": "geth.exe",
                         "commands": {
@@ -83,17 +83,17 @@
                                 ],
                                 "output": [
                                     "Geth",
-                                    "1.6.7"
+                                    "1.7.0"
                                 ]
                             }
                         }
                     },
                     "ia32": {
                         "download": {
-                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.6.7-ab5646c5.zip",
+                            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.7.0-6c6c7b2a.zip",
                             "type": "zip",
-                            "md5": "44f66ec3565ee5b88929af8178a34027",
-                            "bin": "geth-windows-386-1.6.7-ab5646c5\\geth.exe"
+                            "md5": "3d21ea8621dfc96f91c4ab8aa7163471",
+                            "bin": "geth-windows-386-1.7.0-6c6c7b2a\\geth.exe"
                         },
                         "bin": "geth.exe",
                         "commands": {
@@ -103,7 +103,7 @@
                                 ],
                                 "output": [
                                     "Geth",
-                                    "1.6.7"
+                                    "1.7.0"
                                 ]
                             }
                         }

--- a/interface/client/templates/elements/nodeInfo.js
+++ b/interface/client/templates/elements/nodeInfo.js
@@ -105,11 +105,12 @@ Template['elements_nodeInfo'].onCreated(function(){
 });
 
 
-Template['elements_nodeInfo'].onDestroyed(function(){
+Template['elements_nodeInfo'].onDestroyed(function() {
     Meteor.clearInterval(this.peerCountIntervalId);
 
-    if(this.syncFilter)
+    if (this.syncFilter) {
         this.syncFilter.stopWatching();
+    } 
 });
 
 
@@ -120,7 +121,7 @@ Template['elements_nodeInfo'].helpers({
     @method (formattedBlockNumber)
     @return {String}
     */
-    'formattedBlockNumber': function() {
+    formattedBlockNumber: function () {
         return numeral(EthBlocks.latest.number).format('0,0');
     },
     /**
@@ -128,20 +129,20 @@ Template['elements_nodeInfo'].helpers({
 
     @method (timeSinceBlock)
     */
-    'timeSinceBlock': function () {
-        var timeSince = moment(EthBlocks.latest.timestamp, "X");
+    timeSinceBlock: function () {
+        var timeSince = moment(EthBlocks.latest.timestamp, 'X');
         var now = moment();
-        var diff = now.diff(timeSince, "seconds");
+        var diff = now.diff(timeSince, 'seconds');
 
-        if (diff>60) {
-            Helpers.rerun["10s"].tick();
+        if (diff > 60) {
+            Helpers.rerun['10s'].tick();
             return timeSince.fromNow(true);
-        } else if (diff<2) {
-            Helpers.rerun["1s"].tick();
-            return ' <span class="blue">' + TAPi18n.__('mist.nodeInfo.blockReceivedShort') + '</span>'
-        } else {
-            Helpers.rerun["1s"].tick();
-            return diff + "s";
+        } else if (diff < 2) {
+            Helpers.rerun['1s'].tick();
+            return ' <span class="blue">' + TAPi18n.__('mist.nodeInfo.blockReceivedShort') + '</span>';
         }
+
+        Helpers.rerun['1s'].tick();
+        return diff + 's';
     }
 });

--- a/interface/client/templates/elements/nodeInfo.js
+++ b/interface/client/templates/elements/nodeInfo.js
@@ -110,7 +110,7 @@ Template['elements_nodeInfo'].onDestroyed(function() {
 
     if (this.syncFilter) {
         this.syncFilter.stopWatching();
-    } 
+    }
 });
 
 
@@ -133,6 +133,10 @@ Template['elements_nodeInfo'].helpers({
         var timeSince = moment(EthBlocks.latest.timestamp, 'X');
         var now = moment();
         var diff = now.diff(timeSince, 'seconds');
+
+        if (!EthBlocks.latest.timestamp) {
+            return '-';
+        }
 
         if (diff > 60) {
             Helpers.rerun['10s'].tick();

--- a/interface/i18n/mist.de.i18n.json
+++ b/interface/i18n/mist.de.i18n.json
@@ -47,7 +47,7 @@
                 "ethereumNode": "Ethereum Softwareknoten",
                 "network": "Netzwerk",
                 "mainNetwork": "Hauptnetzwerk",
-                "startMining": "⛏ Mining starten (nur auf Testnetz)",
+                "startMining": "⛏ Mining starten",
                 "stopMining": "⛏ Mining stoppen",
                 "externalNode": "externer Softwareknoten aktiv",
                 "nodeMode": "Chain herunterladen",

--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -69,7 +69,7 @@
                 "nodeMode": "Chain download",
                 "fullNode": "Store full blockchain",
                 "lightNode": "Use light Node (experimental!)",
-                "startMining": "⛏ Start mining (Testnet only)",
+                "startMining": "⛏ Start mining",
                 "stopMining": "⛏ Stop mining"
             },
             "window": {

--- a/interface/i18n/mist.es.i18n.json
+++ b/interface/i18n/mist.es.i18n.json
@@ -46,7 +46,7 @@
                 "ethereumNode": "Nodo de Ethereum",
                 "network": "Red",
                 "mainNetwork": "Red principal",
-                "startMining": "⛏ Empezar a minar (sólo Testnet)",
+                "startMining": "⛏ Empezar a minar",
                 "stopMining": "⛏ Parar de minar",
                 "externalNode": "using external node",
                 "openRemix": "Open Remix IDE",

--- a/interface/i18n/mist.fa.i18n.json
+++ b/interface/i18n/mist.fa.i18n.json
@@ -47,7 +47,7 @@
                 "ethereumNode": "Ethereum Node",
                 "network": "Network",
                 "mainNetwork": "Main Network",
-                "startMining": "⛏ Start Mining (Testnet only)",
+                "startMining": "⛏ Start Mining",
                 "stopMining": "⛏ Stop Mining",
                 "openRemix": "Open Remix IDE",
                 "nodeMode": "Chain download",

--- a/interface/i18n/mist.fr.i18n.json
+++ b/interface/i18n/mist.fr.i18n.json
@@ -46,7 +46,7 @@
                 "ethereumNode": "Nœud Ethereum",
                 "network": "Réseau",
                 "mainNetwork": "Réseau principal",
-                "startMining": "⛏ Commencer à miner (seulement pour Testnet)",
+                "startMining": "⛏ Commencer à miner",
                 "stopMining": "⛏ Arrêter de miner",
                 "externalNode": "using external node",
                 "openRemix": "Open Remix IDE",

--- a/interface/i18n/mist.it.i18n.json
+++ b/interface/i18n/mist.it.i18n.json
@@ -46,7 +46,7 @@
                 "ethereumNode": "Nodo Ethereum",
                 "network": "Rete",
                 "mainNetwork": "Rete principale",
-                "startMining": "⛏ Inizia mining (solo Testnet)",
+                "startMining": "⛏ Inizia mining",
                 "stopMining": "⛏ Ferma mining",
                 "externalNode": "using external node",
                 "openRemix": "Open Remix IDE",

--- a/interface/i18n/mist.ja.i18n.json
+++ b/interface/i18n/mist.ja.i18n.json
@@ -46,7 +46,7 @@
                 "ethereumNode": "Ethereum ノード",
                 "network": "ネットワーク",
                 "mainNetwork": "メインネットワーク",
-                "startMining": "⛏ マイニングを始める (テストネット のみ)",
+                "startMining": "⛏ マイニングを始める",
                 "stopMining": "⛏ マイニングを中止する",
                 "externalNode": "using external node",
                 "openRemix": "Open Remix IDE",

--- a/interface/i18n/mist.nb.i18n.json
+++ b/interface/i18n/mist.nb.i18n.json
@@ -46,7 +46,7 @@
                 "ethereumNode": "Ethereum Node",
                 "network": "Nettverk",
                 "mainNetwork": "Hovednettverk",
-                "startMining": "⛏ Start Mining (Kun testnett)",
+                "startMining": "⛏ Start Mining",
                 "stopMining": "⛏ Stopp Mining",
                 "externalNode": "using external node",
                 "openRemix": "Open Remix IDE",

--- a/interface/i18n/mist.nl.i18n.json
+++ b/interface/i18n/mist.nl.i18n.json
@@ -69,7 +69,7 @@
                 "fullNode": "Bewaar volledige blockchain",
                 "lightNode": "Gebruik light Node (experimenteel!)",
                 "mainNetwork": "Hoofdnetwerk",
-                "startMining": "⛏ Start Mining (Alleen testnet)",
+                "startMining": "⛏ Start Mining",
                 "stopMining": "⛏ Stop Mining"
             },
             "window": {

--- a/interface/i18n/mist.pt.i18n.json
+++ b/interface/i18n/mist.pt.i18n.json
@@ -47,7 +47,7 @@
                 "ethereumNode": "Node",
                 "network": "Rede",
                 "mainNetwork": "Rede principal",
-                "startMining": "⛏ Iniciar mineração (somente em teste)",
+                "startMining": "⛏ Iniciar mineração",
                 "stopMining": "⛏ Parar mineração",
                 "externalNode": "using external node",
                 "openRemix": "Open Remix IDE",

--- a/interface/i18n/mist.ru.i18n.json
+++ b/interface/i18n/mist.ru.i18n.json
@@ -46,7 +46,7 @@
                 "ethereumNode": "Ethereum-нода",
                 "network": "Сеть",
                 "mainNetwork": "Основная сеть",
-                "startMining": "⛏ Запустить майнинг (только для тестовой сети)",
+                "startMining": "⛏ Запустить майнинг",
                 "stopMining": "⛏ Остановить майнинг",
                 "externalNode": "using external node",
                 "openRemix": "Open Remix IDE",

--- a/interface/i18n/mist.sq.i18n.json
+++ b/interface/i18n/mist.sq.i18n.json
@@ -51,7 +51,7 @@
                 "nodeMode": "Shkarkim zinxhir",
                 "fullNode": "Ruaj zinxhirin e plotë të blloqeve",
                 "lightNode": "Përdor nyje të lehtë (eksperimentale!)",
-                "startMining": "⛏  Fillo të Prodhosh (Rrjet testimi)",
+                "startMining": "⛏  Fillo të Prodhosh",
                 "stopMining": "⛏ Ndalo së Prodhuari"
             },
             "window": {

--- a/modules/clientBinaryManager.js
+++ b/modules/clientBinaryManager.js
@@ -31,7 +31,6 @@ class Manager extends EventEmitter {
         // check every hour
         setInterval(() => this._checkForNewConfig(true), 1000 * 60 * 60);
 
-        this._resolveEthBinPath();
         return this._checkForNewConfig(restart);
     }
 
@@ -73,7 +72,7 @@ class Manager extends EventEmitter {
             log.warn('Error fetching client binaries config from repo', err);
         })
         .then((latestConfig) => {
-            if(!latestConfig) return;
+            if (!latestConfig) return;
 
             let localConfig;
             let skipedVersion;

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -403,7 +403,7 @@ class EthereumNode extends EventEmitter {
                 case 'dev':
                     args = [
                         '--dev',
-                        '--minerThreads', '1',
+                        '--minerthreads', '1',
                         '--ipcpath', Settings.rpcIpcPath
                     ];
                     break;

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -544,9 +544,9 @@ class EthereumNode extends EventEmitter {
 
         this.defaultNodeType = Settings.nodeType || Settings.loadUserData('node') || DEFAULT_NODE_TYPE;
         this.defaultNetwork = Settings.network || Settings.loadUserData('network') || DEFAULT_NETWORK;
-        this.defaultSyncMode = Settings.syncMode || Settings.loadUserData('syncmode') || DEFAULT_SYNCMODE;
+        this.defaultSyncMode = Settings.syncmode || Settings.loadUserData('syncmode') || DEFAULT_SYNCMODE;
 
-        log.info(Settings.syncMode, Settings.loadUserData('syncmode'), DEFAULT_SYNCMODE);
+        log.info(Settings.syncmode, Settings.loadUserData('syncmode'), DEFAULT_SYNCMODE);
         log.info(`Defaults loaded: ${this.defaultNodeType} ${this.defaultNetwork} ${this.defaultSyncMode}`);
     }
 }

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -377,20 +377,17 @@ class EthereumNode extends EventEmitter {
 
                 switch (network) {
 
-                // STARTS ROPSTEN
+                // Starts Ropsten network
                 case 'test':
-                    args = (nodeType === 'geth') ? [
+                    args = [
                         '--testnet',
                         '--syncmode', syncMode,
                         '--cache', ((process.arch === 'x64') ? '1024' : '512'),
                         '--ipcpath', Settings.rpcIpcPath
-                    ] : [
-                        '--morden',
-                        '--unsafe-transactions'
                     ];
                     break;
 
-                // STARTS RINKEBY
+                // Starts Rinkeby network
                 case 'rinkeby':
                     args = [
                         '--rinkeby',
@@ -400,6 +397,7 @@ class EthereumNode extends EventEmitter {
                     ];
                     break;
 
+                // Starts local network
                 case 'dev':
                     args = [
                         '--dev',
@@ -408,7 +406,7 @@ class EthereumNode extends EventEmitter {
                     ];
                     break;
 
-                // STARTS MAINNET
+                // Starts Main net
                 default:
                     args = (nodeType === 'geth')
                         ? [

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -174,22 +174,15 @@ class EthereumNode extends EventEmitter {
             log.info('Restart node', newType, newNetwork);
 
             return this.stop()
-                .then(() => {
-                    Windows.loading.show();
-                })
-                .then(() => {
-                    return this._start(
+                .then(() => Windows.loading.show())
+                .then(() => this._start(
                       newType || this.type,
                       newNetwork || this.network,
                       syncMode || this.syncMode
-                    );
-                })
-                .then(() => {
-                    Windows.loading.hide();
-                })
+                    ))
+                .then(() => Windows.loading.hide())
                 .catch((err) => {
                     log.error('Error restarting node', err);
-
                     throw err;
                 });
         });

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -31,7 +31,7 @@ const createMenu = function (webviews) {
 };
 
 
-const restartNode = function (newType, newNetwork, syncMode) {
+const restartNode = function (newType, newNetwork, syncMode, webviews) {
     newNetwork = newNetwork || ethereumNode.network;
 
     log.info('Switch node', newType, newNetwork);
@@ -45,6 +45,37 @@ const restartNode = function (newType, newNetwork, syncMode) {
         })
         .catch((err) => {
             log.error('Error switching node', err);
+        });
+};
+
+
+const startMining = (webviews) => {
+    ethereumNode.send('miner_start', [1])
+        .then((ret) => {
+            log.info('miner_start', ret.result);
+
+            if (ret.result) {
+                global.mining = true;
+                createMenu(webviews);
+            }
+        })
+        .catch((err) => {
+            log.error('miner_start', err);
+        });
+};
+
+const stopMining = (webviews) => {
+    ethereumNode.send('miner_stop', [1])
+        .then((ret) => {
+            log.info('miner_stop', ret.result);
+
+            if (ret.result) {
+                global.mining = false;
+                createMenu(webviews);
+            }
+        })
+        .catch((err) => {
+            log.error('miner_stop', err);
         });
 };
 
@@ -236,7 +267,7 @@ let menuTempl = function (webviews) {
                     }
                 }
             }]
-        });
+    });
 
     // EDIT
     menu.push({
@@ -457,20 +488,11 @@ let menuTempl = function (webviews) {
         if (gethClient) {
             nodeSubmenu.push({
                 label: `Geth ${gethClient.version}`,
-                checked: ethereumNode.isOwnNode && ethereumNode.isGeth && !ethereumNode.isLightMode,
+                checked: ethereumNode.isOwnNode && ethereumNode.isGeth,
                 enabled: ethereumNode.isOwnNode,
                 type: 'checkbox',
                 click() {
-                    restartNode('geth', null, 'fast');
-                },
-            });
-            nodeSubmenu.push({
-                label: `Geth ${gethClient.version} Light Mode (beta)`,
-                checked: ethereumNode.isOwnNode && ethereumNode.isGeth && ethereumNode.isLightMode,
-                enabled: ethereumNode.isOwnNode,
-                type: 'checkbox',
-                click() {
-                    restartNode('geth', null, 'light');
+                    restartNode('geth', null, 'fast', webviews);
                 },
             });
         }
@@ -502,9 +524,9 @@ let menuTempl = function (webviews) {
         submenu: [
             {
                 label: i18n.t('mist.applicationMenu.develop.mainNetwork'),
-                accelerator: 'CommandOrControl+Shift+1',
+                accelerator: 'CommandOrControl+Alt+1',
                 checked: ethereumNode.isOwnNode && ethereumNode.isMainNetwork,
-                enabled: ethereumNode.isOwnNode && !ethereumNode.isMainNetwork,
+                enabled: ethereumNode.isOwnNode,
                 type: 'checkbox',
                 click() {
                     restartNode(ethereumNode.type, 'main');
@@ -512,9 +534,9 @@ let menuTempl = function (webviews) {
             },
             {
                 label: 'Ropsten - Test network',
-                accelerator: 'CommandOrControl+Shift+2',
+                accelerator: 'CommandOrControl+Alt+2',
                 checked: ethereumNode.isOwnNode && ethereumNode.network === 'test',
-                enabled: ethereumNode.isOwnNode && ethereumNode.network !== 'test',
+                enabled: ethereumNode.isOwnNode,
                 type: 'checkbox',
                 click() {
                     restartNode(ethereumNode.type, 'test');
@@ -522,9 +544,9 @@ let menuTempl = function (webviews) {
             },
             {
                 label: 'Rinkeby - Test network',
-                accelerator: 'CommandOrControl+Shift+3',
+                accelerator: 'CommandOrControl+Alt+3',
                 checked: ethereumNode.isOwnNode && ethereumNode.network === 'rinkeby',
-                enabled: ethereumNode.isOwnNode && ethereumNode.network !== 'rinkeby',
+                enabled: ethereumNode.isOwnNode,
                 type: 'checkbox',
                 click() {
                     restartNode(ethereumNode.type, 'rinkeby');
@@ -532,9 +554,9 @@ let menuTempl = function (webviews) {
             },
             {
                 label: 'Solo network',
-                accelerator: 'CommandOrControl+Shift+4',
+                accelerator: 'CommandOrControl+Alt+4',
                 checked: ethereumNode.isOwnNode && ethereumNode.isDevNetwork,
-                enabled: ethereumNode.isOwnNode && !ethereumNode.isDevNetwork,
+                enabled: ethereumNode.isOwnNode,
                 type: 'checkbox',
                 click() {
                     restartNode(ethereumNode.type, 'dev');
@@ -542,42 +564,42 @@ let menuTempl = function (webviews) {
             }
         ] });
 
-    devToolsMenu.push({
-        label: (global.mining) ? i18n.t('mist.applicationMenu.develop.stopMining') : i18n.t('mist.applicationMenu.develop.startMining'),
-        accelerator: 'CommandOrControl+Shift+M',
-        enabled: ethereumNode.isOwnNode &&
-                (ethereumNode.isTestNetwork || ethereumNode.isDevNetwork),
-        click() {
-            if (!global.mining) {
-                ethereumNode.send('miner_start', [1])
-                    .then((ret) => {
-                        log.info('miner_start', ret.result);
+    // Light mode switch should appear when not in Solo Mode (dev network)
+    if (ethereumNode.isOwnNode && ethereumNode.isGeth && !ethereumNode.isDevNetwork) {
+        if (!ethereumNode.isLightMode) {
+            devToolsMenu.push({
+                label: 'Enable Light Mode (experimental)',
+                enabled: true,
+                click() {
+                    restartNode('geth', null, 'light');
+                },
+            });
+        } else {
+            devToolsMenu.push({
+                label: 'Disable Light Mode',
+                enabled: true,
+                click() {
+                    restartNode('geth', null, 'fast');
+                },
+            });
+        }
+    }
 
-                        if (ret.result) {
-                            global.mining = true;
-                            createMenu(webviews);
-                        }
-                    })
-                    .catch((err) => {
-                        log.error('miner_start', err);
-                    });
-            } else {
-                ethereumNode.send('miner_stop', [1])
-                    .then((ret) => {
-                        log.info('miner_stop', ret.result);
-
-                        if (ret.result) {
-                            global.mining = false;
-                            createMenu(webviews);
-                        }
-                    })
-                    .catch((err) => {
-                        log.error('miner_stop', err);
-                    });
+    // Enables mining menu: only in Solo mode and Ropsten network (testnet)
+    if (ethereumNode.isOwnNode && (ethereumNode.isTestNetwork || ethereumNode.isDevNetwork)) {
+        devToolsMenu.push({
+            label: (global.mining) ? i18n.t('mist.applicationMenu.develop.stopMining') : i18n.t('mist.applicationMenu.develop.startMining'),
+            accelerator: 'CommandOrControl+Shift+M',
+            enabled: true,
+            click() {
+                if (global.mining) {
+                    stopMining(webviews);
+                } else {
+                    startMining(webviews);
+                }
             }
-        },
-    });
-
+        });
+    }
 
     menu.push({
         label: ((global.mining) ? '⛏ ' : '') + i18n.t('mist.applicationMenu.develop.label'),

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -570,6 +570,7 @@ let menuTempl = function (webviews) {
             label: 'Sync with Light client (beta)',
             enabled: true,
             checked: ethereumNode.isLightMode,
+            type: 'checkbox',
             click() {
                 restartNode('geth', null, (ethereumNode.isLightMode) ? 'fast' : 'light');
             },

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -31,12 +31,12 @@ const createMenu = function (webviews) {
 };
 
 
-const restartNode = function (newType, newNetwork) {
+const restartNode = function (newType, newNetwork, syncMode) {
     newNetwork = newNetwork || ethereumNode.network;
 
     log.info('Switch node', newType, newNetwork);
 
-    return ethereumNode.restart(newType, newNetwork)
+    return ethereumNode.restart(newType, newNetwork, syncMode)
         .then(() => {
             Windows.getByType('main').load(global.interfaceAppUrl);
 

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -566,13 +566,14 @@ let menuTempl = function (webviews) {
 
     // Light mode switch should appear when not in Solo Mode (dev network)
     if (ethereumNode.isOwnNode && ethereumNode.isGeth && !ethereumNode.isDevNetwork) {
-            devToolsMenu.push({
-                label: 'Sync with Light client (beta)',
-                enabled: ethereumNode.isLightMode,
-                click() {
-                    restartNode('geth', null, (ethereumNode.isLightMode) ? 'fast' : 'light');
-                },
-            });
+        devToolsMenu.push({
+            label: 'Sync with Light client (beta)',
+            enabled: true,
+            checked: ethereumNode.isLightMode,
+            click() {
+                restartNode('geth', null, (ethereumNode.isLightMode) ? 'fast' : 'light');
+            },
+        });
     }
 
     // Enables mining menu: only in Solo mode and Ropsten network (testnet)

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -566,23 +566,13 @@ let menuTempl = function (webviews) {
 
     // Light mode switch should appear when not in Solo Mode (dev network)
     if (ethereumNode.isOwnNode && ethereumNode.isGeth && !ethereumNode.isDevNetwork) {
-        if (!ethereumNode.isLightMode) {
             devToolsMenu.push({
-                label: 'Enable Light Mode (experimental)',
-                enabled: true,
+                label: 'Sync with Light client (beta)',
+                enabled: ethereumNode.isLightMode,
                 click() {
-                    restartNode('geth', null, 'light');
+                    restartNode('geth', null, (ethereumNode.isLightMode) ? 'fast' : 'light');
                 },
             });
-        } else {
-            devToolsMenu.push({
-                label: 'Disable Light Mode',
-                enabled: true,
-                click() {
-                    restartNode('geth', null, 'fast');
-                },
-            });
-        }
     }
 
     // Enables mining menu: only in Solo mode and Ropsten network (testnet)

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -436,7 +436,6 @@ let menuTempl = function (webviews) {
                 shell.showItemInFolder(`${Settings.userDataPath}/node.log`);
             } catch (e) {
                 log.info(e);
-                log = 'Couldn\'t load log file.';
             }
         },
     });

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -455,17 +455,24 @@ let menuTempl = function (webviews) {
         const gethClient = ClientBinaryManager.getClient('geth');
 
         if (gethClient) {
-            nodeSubmenu.push(
-                {
-                    label: `Geth ${gethClient.version} (Go)`,
-                    checked: ethereumNode.isOwnNode && ethereumNode.isGeth,
-                    enabled: ethereumNode.isOwnNode,
-                    type: 'checkbox',
-                    click() {
-                        restartNode('geth');
-                    },
-                }
-            );
+            nodeSubmenu.push({
+                label: `Geth ${gethClient.version}`,
+                checked: ethereumNode.isOwnNode && ethereumNode.isGeth && !ethereumNode.isLightMode,
+                enabled: ethereumNode.isOwnNode,
+                type: 'checkbox',
+                click() {
+                    restartNode('geth', null, 'fast');
+                },
+            });
+            nodeSubmenu.push({
+                label: `Geth ${gethClient.version} Light Mode (beta)`,
+                checked: ethereumNode.isOwnNode && ethereumNode.isGeth && ethereumNode.isLightMode,
+                enabled: ethereumNode.isOwnNode,
+                type: 'checkbox',
+                click() {
+                    restartNode('geth', null, 'light');
+                },
+            });
         }
 
         if (ethClient) {

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -41,6 +41,7 @@ const restartNode = function (newType, newNetwork, syncMode) {
             Windows.getByType('main').load(global.interfaceAppUrl);
 
             createMenu(webviews);
+            log.info('Node switch successful.');
         })
         .catch((err) => {
             log.error('Error switching node', err);

--- a/modules/nodeSync.js
+++ b/modules/nodeSync.js
@@ -145,12 +145,11 @@ class NodeSync extends EventEmitter {
                         return ethereumNode.send('eth_getBlockByNumber', ['latest', false])
                             .then((ret2) => {
                                 const blockResult = ret2.result;
-
                                 const now = Math.floor(new Date().getTime() / 1000);
 
-                                const diff = now - +blockResult.timestamp;
+                                log.debug(`Last block: ${Number(blockResult.number)}; timestamp: ${blockResult.timestamp}`);
 
-                                log.debug(`Last block: ${Number(blockResult.number)}, ${diff}s ago`);
+                                const diff = now - +blockResult.timestamp;
 
                                 // need sync if > 1 minute
                                 if (diff > 60) {

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -115,6 +115,14 @@ const argv = require('yargs')
             type: 'string',
             group: 'Mist options:',
         },
+        syncmode: {
+            demand: false,
+            requiresArg: true,
+            describe: 'Geth synchronization mode: [fast|light|full]',
+            nargs: 1,
+            type: 'string',
+            group: 'Mist options:',
+        },
         version: {
             alias: 'v',
             demand: false,
@@ -151,6 +159,9 @@ if (argv.ipcpath) {
     argv.nodeOptions.push('--ipcpath', argv.ipcpath);
 }
 
+if (argv.syncmode) {
+    argv.nodeOptions.push('--syncmode', argv.syncmode);
+}
 
 class Settings {
     init() {
@@ -341,7 +352,9 @@ class Settings {
 
       // try to read it
         try {
-            return fs.readFileSync(fullPath, { encoding: 'utf8' });
+            const data = fs.readFileSync(fullPath, { encoding: 'utf8' });
+            this._log.debug(`Reading "${data}" from ${fullPath}`);
+            return data;
         } catch (err) {
             this._log.warn(`File not readable: ${fullPath}`, err);
         }
@@ -356,6 +369,7 @@ class Settings {
         const fullPath = this.constructUserDataPath(path2);
 
         try {
+            this._log.debug(`Saving "${data}" to ${fullPath}`);
             fs.writeFileSync(fullPath, data, { encoding: 'utf8' });
         } catch (err) {
             this._log.warn(`Unable to write to ${fullPath}`, err);

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -159,8 +159,8 @@ if (argv.ipcpath) {
     argv.nodeOptions.push('--ipcpath', argv.ipcpath);
 }
 
-if (argv.syncmode) {
-    argv.nodeOptions.push('--syncmode', argv.syncmode);
+if (argv.nodeOptions && argv.nodeOptions.syncmode) {
+    argv.push('--syncmode', argv.nodeOptions.syncmode);
 }
 
 class Settings {
@@ -286,6 +286,10 @@ class Settings {
 
     get network() {
         return argv.network;
+    }
+
+    get syncmode() {
+        return argv.syncmode;
     }
 
     get nodeOptions() {


### PR DESCRIPTION
#### What does it do?

- [x] Updates to geth 1.7.0
- [x] Adds Light client option on the menu
- [x] Changes `--fast` to `--syncmode [fast/light]` geth flag
- [x] Persists syncMode locally
- [x] Restructure network-related menus
- [x] Changes network keystrokes to prevent conflicts in MacOS (Cmd+Opt+[1234] instead of Cmd+Shift+[1234])
- [x] Passes `--syncmode` param to node
- [x] Intercepts `--node-syncmode` param for internal use in Mist
- [ ] `nodeSync.js:153` error: `blockResult.timestamp`
- [ ] Way to inform wallet about filter speed limitations

#### Any helpful background information?

#### Which code should the reviewer start with?

`modules/ethereumNode.js`

- [x] Wallet tracks transaction correctly

#### Relevant screenshots?

Before
![image](https://user-images.githubusercontent.com/47108/30668091-1256d35c-9e30-11e7-99a5-a67c7b7ddba7.png)
![image](https://user-images.githubusercontent.com/47108/30668105-1bd9a288-9e30-11e7-93ef-c366f97a77e9.png)
