### PR TITLE
Fixing log message

### DIFF
--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -465,7 +465,7 @@ class EthereumNode extends EventEmitter {
                                     error.tag = UNABLE_TO_BIND_PORT_ERROR;
                                 }
 
-                                log.debug(error.message);
+                                log.debug(error);
 
                                 return reject(error);
                             }

--- a/modules/ethereumNode.js
+++ b/modules/ethereumNode.js
@@ -465,7 +465,7 @@ class EthereumNode extends EventEmitter {
                                     error.tag = UNABLE_TO_BIND_PORT_ERROR;
                                 }
 
-                                log.debug(err.message);
+                                log.debug(error.message);
 
                                 return reject(error);
                             }


### PR DESCRIPTION
#### What does it do?

Fixes an undefined variable in current scope. Probably a typo.

#### How to reproduce it?

1. Configure your Mist to run on main net, and close it.
2. Start a separated geth node in testnet `geth --rinkeby`
3. Start mist

Expected result is to warn "Bind address already in use".
Actual result: uncaught exception.

This PR aims to fix this.

