### PR TITLE
Refactors window logic/state into module

### DIFF
--- a/interface/client/templates/popupWindows/about.html
+++ b/interface/client/templates/popupWindows/about.html
@@ -10,7 +10,7 @@
                 License {{mist.license}}<br>
                 GitHub <a href="https://github.com/ethereum/mist" target="_blank">github.com/ethereum/mist</a>
             </p>
-            <small>Copyright 2016 Ethereum Foundation</small>
+            <small>Copyright 2017 Ethereum Foundation</small>
         </div>
     </div>
 </template>

--- a/main.js
+++ b/main.js
@@ -165,7 +165,6 @@ async function init() {
 
         // Initialise window mgr
         Windows.init();
-        store.dispatch({ type: 'WINDOWS::INIT_FINISH' });
 
         // Enable the Swarm protocol
         protocol.registerHttpProtocol('bzz', (request, callback) => {
@@ -195,79 +194,16 @@ async function init() {
         // add menu already here, so we have copy and paste functionality
         appMenu();
 
+        global.defaultWindow = windowStateKeeper({ defaultWidth: 1024 + 208, defaultHeight: 720 });
+
         // Create the browser window.
-
-        const defaultWindow = windowStateKeeper({
-            defaultWidth: 1024 + 208,
-            defaultHeight: 720
-        });
-
-        store.dispatch({ type: 'MAIN_WINDOW::CREATE_START' });
-
-        // MIST
-        if (global.mode === 'mist') {
-            mainWindow = Windows.create('main', {
-                primary: true,
-                electronOptions: {
-                    width: Math.max(defaultWindow.width, 500),
-                    height: Math.max(defaultWindow.height, 440),
-                    x: defaultWindow.x,
-                    y: defaultWindow.y,
-                    webPreferences: {
-                        nodeIntegration: true, /* necessary for webviews;
-                            require will be removed through preloader */
-                        preload: `${__dirname}/modules/preloader/mistUI.js`,
-                        'overlay-fullscreen-video': true,
-                        'overlay-scrollbars': true,
-                        experimentalFeatures: true,
-                    },
-                },
-            });
-            store.dispatch({ type: 'MAIN_WINDOW::CREATE_SUCCESS' });
-
-        // WALLET
-        } else {
-            mainWindow = Windows.create('main', {
-                primary: true,
-                electronOptions: {
-                    width: Math.max(defaultWindow.width, 500),
-                    height: Math.max(defaultWindow.height, 440),
-                    x: defaultWindow.x,
-                    y: defaultWindow.y,
-                    webPreferences: {
-                        preload: `${__dirname}/modules/preloader/walletMain.js`,
-                        'overlay-fullscreen-video': true,
-                        'overlay-scrollbars': true,
-                    },
-                },
-            });
-            store.dispatch({ type: 'MAIN_WINDOW::CREATE_SUCCESS' });
-        }
+        mainWindow = Windows.create('main');
 
         // Delegating events to save window bounds on windowStateKeeper
-        defaultWindow.manage(mainWindow.window);
+        global.defaultWindow.manage(mainWindow.window);
 
         if (!Settings.inAutoTestMode) {
-            store.dispatch({ type: 'SPLASH_WINDOW::CREATE_START' });
-
-            splashWindow = Windows.create('splash', {
-                primary: true,
-                url: `${global.interfacePopupsUrl}#splashScreen_${global.mode}`,
-                show: true,
-                electronOptions: {
-                    width: 400,
-                    height: 230,
-                    resizable: false,
-                    backgroundColor: '#F6F6F6',
-                    useContentSize: true,
-                    frame: false,
-                    webPreferences: {
-                        preload: `${__dirname}/modules/preloader/splashScreen.js`,
-                    },
-                },
-            });
-
-            store.dispatch({ type: 'SPLASH_WINDOW::CREATE_SUCCESS' });
+            splashWindow = Windows.create('splash');
         }
 
         // check time sync
@@ -406,15 +342,7 @@ async function init() {
                     log.info('No accounts setup yet, lets do onboarding first.');
 
                     return new Q((resolve, reject) => {
-                        store.dispatch({ type: 'ONBOARDING_WINDOW::CREATE_START' });
-                        const onboardingWindow = Windows.createPopup('onboardingScreen', {
-                            primary: true,
-                            electronOptions: {
-                                width: 576,
-                                height: 442,
-                            },
-                        });
-                        store.dispatch({ type: 'ONBOARDING_WINDOW::CREATE_SUCCESS' });
+                        const onboardingWindow = Windows.createPopup('onboardingScreen');
 
                         onboardingWindow.on('closed', () => {
                             store.dispatch({ type: 'ONBOARDING_WINDOW::CLOSE' });

--- a/modules/clientBinaryManager.js
+++ b/modules/clientBinaryManager.js
@@ -128,16 +128,7 @@ class Manager extends EventEmitter {
 
                     log.debug('New client binaries config found, asking user if they wish to update...');
 
-                    const wnd = Windows.createPopup('clientUpdateAvailable', _.extend({
-                        useWeb3: false,
-                        electronOptions: {
-                            width: 600,
-                            height: 340,
-                            alwaysOnTop: false,
-                            resizable: false,
-                            maximizable: false,
-                        },
-                    }, {
+                    const wnd = Windows.createPopup('clientUpdateAvailable', {
                         sendData: {
                             uiAction_sendData: {
                                 name: nodeType,
@@ -147,7 +138,7 @@ class Manager extends EventEmitter {
                                 restart,
                             },
                         },
-                    }), (update) => {
+                    }, (update) => {
                         // update
                         if (update === 'update') {
                             this._writeLocalConfig(latestConfig);

--- a/modules/core/ui/reducer.js
+++ b/modules/core/ui/reducer.js
@@ -1,11 +1,20 @@
-const initialState = {
+export const initialState = {
+    aboutWindowCreated: false,
     appQuit: false,
+    clientUpdateAvailableWindowCreated: false,
+    connectAccountWindowCreated: false,
+    importAccountWindowCreated: false,
+    loadingWindowCreated: false,
     mainWindowCreated: false,
     mainWindowVisible: false,
-    onboardingWindowCreated: false,
-    onboardingWindowVisible: false,
+    onboardingScreenWindowCreated: false,
+    onboardingScreenWindowVisible: false,
+    remixWindowCreated: false,
+    requestAccountWindowCreated: false,
+    sendTransactionConfirmationWindowCreated: false,
     splashWindowCreated: false,
     splashWindowVisible: false,
+    updateAvailableWindowCreated: false,
     windowsInit: false,
 };
 
@@ -15,25 +24,21 @@ const ui = (state = initialState, action) => {
             return Object.assign({}, state, { appQuit: true });
         case 'MAIN_WINDOW::CLOSE':
             return Object.assign({}, state, { mainWindowVisible: false });
-        case 'MAIN_WINDOW::CREATE_SUCCESS':
-            return Object.assign({}, state, { mainWindowCreated: true });
+        case '[MAIN]:WINDOW:CREATE_FINISH':
+            return Object.assign({}, state, { [`${action.payload.type}WindowCreated`]: true });
         case 'MAIN_WINDOW::SHOW':
             return Object.assign({}, state, { mainWindowVisible: true });
         case 'MAIN_WINDOW::HIDE':
             return Object.assign({}, state, { mainWindowVisible: false });
         case 'ONBOARDING_WINDOW::CLOSE':
-            return Object.assign({}, state, { onboardingWindowVisible: false });
-        case 'ONBOARDING_WINDOW::CREATE_SUCCESS':
-            return Object.assign({}, state, { onboardingWindowCreated: true, onboardingWindowVisible: true });
+            return Object.assign({}, state, { onboardingScreenWindowVisible: false });
         case 'SPLASH_WINDOW::CLOSE':
             return Object.assign({}, state, { splashWindowVisible: false });
-        case 'SPLASH_WINDOW::CREATE_SUCCESS':
-            return Object.assign({}, state, { splashWindowCreated: true });
         case 'SPLASH_WINDOW::SHOW':
             return Object.assign({}, state, { splashWindowVisible: true });
         case 'SPLASH_WINDOW::HIDE':
             return Object.assign({}, state, { splashWindowVisible: false });
-        case 'WINDOWS::INIT_FINISH':
+        case '[MAIN]:WINDOWS:INIT_FINISH':
             return Object.assign({}, state, { windowsInit: true });
         default:
             return state;

--- a/modules/ipc/methods/eth_sendTransaction.js
+++ b/modules/ipc/methods/eth_sendTransaction.js
@@ -54,16 +54,7 @@ module.exports = class extends BaseProcessor {
             }
 
             const modalWindow = Windows.createPopup('sendTransactionConfirmation', {
-                sendData: {
-                    uiAction_sendData: payload.params[0],
-                },
-                electronOptions: {
-                    width: 580,
-                    height: 550,
-                    alwaysOnTop: true,
-                    enableLargerThanScreen: false,
-                    resizable: true
-                },
+                sendData: { uiAction_sendData: payload.params[0] }
             });
 
             BlurOverlay.enable();

--- a/modules/ipcCommunicator.js
+++ b/modules/ipcCommunicator.js
@@ -219,14 +219,7 @@ ipc.on('backendAction_importWalletFile', (e, path, pw) => {
 
 
 const createAccountPopup = (e) => {
-    Windows.createPopup('requestAccount', {
-        ownerId: e.sender.id,
-        electronOptions: {
-            width: 400,
-            height: 230,
-            alwaysOnTop: true,
-        },
-    });
+    Windows.createPopup('requestAccount', { ownerId: e.sender.id });
 };
 
 // MIST API
@@ -236,16 +229,7 @@ ipc.on('mistAPI_requestAccount', (e) => {
     if (global.mode === 'wallet') {
         createAccountPopup(e);
     } else { // Mist
-        Windows.createPopup('connectAccount', {
-            ownerId: e.sender.id,
-            electronOptions: {
-                width: 460,
-                height: 520,
-                maximizable: false,
-                minimizable: false,
-                alwaysOnTop: true,
-            },
-        });
+        Windows.createPopup('connectAccount', { ownerId: e.sender.id });
     }
 });
 

--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -96,13 +96,7 @@ let menuTempl = function (webviews) {
             {
                 label: i18n.t('mist.applicationMenu.app.about', { app: Settings.appName }),
                 click() {
-                    Windows.createPopup('about', {
-                        electronOptions: {
-                            width: 420,
-                            height: 230,
-                            alwaysOnTop: true,
-                        },
-                    });
+                    Windows.createPopup('about');
                 },
             },
             {
@@ -172,11 +166,7 @@ let menuTempl = function (webviews) {
                 label: i18n.t('mist.applicationMenu.file.newAccount'),
                 accelerator: 'CommandOrControl+N',
                 click() {
-                    Windows.createPopup('requestAccount', {
-                        electronOptions: {
-                            width: 420, height: 230, alwaysOnTop: true,
-                        },
-                    });
+                    Windows.createPopup('requestAccount');
                 },
             },
             {
@@ -184,11 +174,7 @@ let menuTempl = function (webviews) {
                 accelerator: 'CommandOrControl+I',
                 enabled: ethereumNode.isMainNetwork,
                 click() {
-                    Windows.createPopup('importAccount', {
-                        electronOptions: {
-                            width: 600, height: 370, alwaysOnTop: true,
-                        },
-                    });
+                    Windows.createPopup('importAccount');
                 },
             },
             {
@@ -415,17 +401,7 @@ let menuTempl = function (webviews) {
             label: i18n.t('mist.applicationMenu.develop.openRemix'),
             enabled: true,
             click() {
-                Windows.createPopup('remix', {
-                    url: 'https://remix.ethereum.org',
-                    electronOptions: {
-                        width: 1024,
-                        height: 720,
-                        center: true,
-                        frame: true,
-                        resizable: true,
-                        titleBarStyle: 'default',
-                    }
-                });
+                Windows.createPopup('remix');
             },
         });
     }
@@ -610,13 +586,7 @@ let menuTempl = function (webviews) {
             {
                 label: i18n.t('mist.applicationMenu.app.about', { app: Settings.appName }),
                 click() {
-                    Windows.createPopup('about', {
-                        electronOptions: {
-                            width: 420,
-                            height: 230,
-                            alwaysOnTop: true,
-                        },
-                    });
+                    Windows.createPopup('about');
                 },
             },
             {

--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -65,16 +65,7 @@ const check = exports.check = () => {
 function showWindow(options) {
     log.debug('Show update checker window');
 
-    return Windows.createPopup('updateAvailable', _.extend({
-        useWeb3: false,
-        electronOptions: {
-            width: 580,
-            height: 250,
-            alwaysOnTop: true,
-            resizable: false,
-            maximizable: false,
-        },
-    }, options));
+    return Windows.createPopup('updateAvailable', options);
 }
 
 

--- a/tests/unit/core/ui/reducer.test.js
+++ b/tests/unit/core/ui/reducer.test.js
@@ -1,0 +1,20 @@
+import { assert } from 'chai';
+import reducer, { initialState } from '../../../../modules/core/ui/reducer';
+
+describe('the ui reducer', () => {
+    it('should return a default initial state', () => {
+        assert.deepEqual(reducer(undefined, {}), initialState);
+    });
+
+    it('should handle the "[MAIN]:WINDOW:CREATE_FINISH" action', () => {
+        const action = {
+            type: '[MAIN]:WINDOW:CREATE_FINISH',
+            payload: { type: 'about' }
+        };
+        const expectedState = Object.assign({}, initialState, {
+            aboutWindowCreated: true,
+        });
+
+        assert.deepEqual(reducer(initialState, action), expectedState);
+    });
+});


### PR DESCRIPTION
#### What does it do?
Refactors Window logic into the windows module. 
#### Any helpful background information?
There's duplicate Window state throughout the application, where ever a new window needs to be created. The goal is to hide as much of that away as possible within the Window module.
#### Which code should the reviewer start with?
- In `main.js`, you can see how much cleaner it is to create windows.
- The refactored logic is in `/modules/windows.js`. Now all default settings are in a method called `getDefaultOptionsForType`.