### PR TITLE
Mac OSX High Sierra fix + Skips timesync check flag

### DIFF
--- a/main.js
+++ b/main.js
@@ -270,26 +270,25 @@ onReady = () => {
         });
     }
 
-    // check time sync
-    // var ntpClient = require('ntp-client');
-    // ntpClient.getNetworkTime("pool.ntp.org", 123, function(err, date) {
-    timesync.checkEnabled((err, enabled) => {
-        if (err) {
-            log.error('Couldn\'t get time from NTP time sync server.', err);
-            return;
-        }
+    // Checks time sync
+    if (!Settings.skiptimesynccheck) {
+        timesync.checkEnabled((err, enabled) => {
+            if (err) {
+                log.error('Couldn\'t infer if computer automatically syncs time.', err);
+                return;
+            }
 
-        if (!enabled) {
-            dialog.showMessageBox({
-                type: 'warning',
-                buttons: ['OK'],
-                message: global.i18n.t('mist.errors.timeSync.title'),
-                detail: `${global.i18n.t('mist.errors.timeSync.description')}\n\n${global.i18n.t(`mist.errors.timeSync.${process.platform}`)}`,
-            }, () => {
-            });
-        }
-    });
-
+            if (!enabled) {
+                dialog.showMessageBox({
+                    type: 'warning',
+                    buttons: ['OK'],
+                    message: global.i18n.t('mist.errors.timeSync.title'),
+                    detail: `${global.i18n.t('mist.errors.timeSync.description')}\n\n${global.i18n.t(`mist.errors.timeSync.${process.platform}`)}`,
+                }, () => {
+                });
+            }
+        });
+    }
 
     const kickStart = () => {
         // client binary stuff

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -132,6 +132,14 @@ const argv = require('yargs')
             group: 'Mist options:',
             type: 'boolean',
         },
+        skiptimesynccheck: {
+            demand: false,
+            requiresArg: false,
+            nargs: 0,
+            describe: 'Disable checks for the presence of automatic time sync on your OS.',
+            group: 'Mist options:',
+            type: 'boolean',
+        },
         '': {
             describe: 'To pass options to the underlying node (e.g. Geth) use the --node- prefix, e.g. --node-datadir',
             group: 'Node options:',
@@ -140,7 +148,6 @@ const argv = require('yargs')
     .help('h')
     .alias('h', 'help')
     .parse(process.argv.slice(1));
-
 
 argv.nodeOptions = [];
 
@@ -302,6 +309,10 @@ class Settings {
 
     set language(langCode) {
         this.saveConfig('ui.i18n', langCode);
+    }
+
+    get skiptimesynccheck() {
+        return argv.skiptimesynccheck;
     }
 
     initConfig() {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "minimongo-standalone": "^1.1.0-3",
     "numeral": "^2.0.6",
     "oboe": "^2.1.3",
-    "os-timesync": "^1.0.7",
+    "os-timesync": "^1.0.8",
     "semver": "^5.1.0",
     "solc": "^0.4.15",
     "swarm-js": "^0.1.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3814,9 +3814,9 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-timesync@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/os-timesync/-/os-timesync-1.0.7.tgz#fc7ea7e6de1fc88742880cd08ff284327678e20d"
+os-timesync@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/os-timesync/-/os-timesync-1.0.8.tgz#390ae8832e20183ea3fc1b97ea90bcbc97c0178f"
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
#### What does it do?

- It updates `os-timesync` package.
- It adds a flag `--skiptimesynccheck` on Mist and EW startup process. When used, it'll prevent checking if the OS clock is automatically set to update. 

#### Any helpful background information?

People using Mac OSX High Sierra have reported issues: https://github.com/ethereum/mist/issues/3098

People that used custom NTP time syncing have found the warning annoying.

#### Which code should the reviewer start with?

either way.

#### New dependencies? What are they used for?

Updated `os-timesync` package

#### Relevant screenshots?

-