### PR TITLE
Locking script file to a specific commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ cache:
 
 install:
   - echo $PATH
-  - PATH=$PATH:$HOME/.meteor && curl -L https://raw.githubusercontent.com/arunoda/travis-ci-meteor-packages/master/configure.sh | /bin/sh
+  - PATH=$PATH:$HOME/.meteor && curl -L https://raw.githubusercontent.com/arunoda/travis-ci-meteor-packages/1390e0f96162d0d70fc1e60a6b0f4f891a0e8f42/configure.sh | /bin/sh
   - yarn global add gulp-cli meteor-build-client
   - yarn
 


### PR DESCRIPTION
#### What does it do?

This script sets up meteor environment for travis testing. This PR locks the file to that commit, so the outcome is predictable.
