### PR TITLE
Generic window refactor

### DIFF
--- a/interface/client/appStart.js
+++ b/interface/client/appStart.js
@@ -74,7 +74,7 @@ Meteor.startup(function () {
         mistInit();
     }
 
-    if (store) { store.dispatch(getLanguage()); }
+    store.dispatch(getLanguage());
 
     // change moment and numeral language, when language changes
     Tracker.autorun(function () {

--- a/interface/client/appStart.js
+++ b/interface/client/appStart.js
@@ -74,7 +74,7 @@ Meteor.startup(function () {
         mistInit();
     }
 
-    store.dispatch(getLanguage());
+    if (store) { store.dispatch(getLanguage()); }
 
     // change moment and numeral language, when language changes
     Tracker.autorun(function () {

--- a/interface/client/templates/index.html
+++ b/interface/client/templates/index.html
@@ -12,6 +12,7 @@
 
     {{> GlobalNotifications}}
 
+    <div id="generic-renderer"></div>
     <!-- Form Helper iFrame -->
     <iframe id="dapp-form-helper-iframe" name="dapp-form-helper-iframe" src="javascript:false;"></iframe>
 </body>

--- a/interface/client/templates/index.html
+++ b/interface/client/templates/index.html
@@ -12,7 +12,7 @@
 
     {{> GlobalNotifications}}
 
-    <div id="generic-renderer"></div>
+    <div id="generic-body"></div>
     <!-- Form Helper iFrame -->
     <iframe id="dapp-form-helper-iframe" name="dapp-form-helper-iframe" src="javascript:false;"></iframe>
 </body>

--- a/interface/client/templates/index.js
+++ b/interface/client/templates/index.js
@@ -4,7 +4,7 @@ Template Controllers
 @module Templates
 */
 
-/**a
+/**
 The body template
 
 @class [template] body
@@ -13,7 +13,7 @@ The body template
 
 // Generic windows reuse windows by switching the template
 ipc.on('uiAction_switchTemplate', (e, templateName) => {
-    TemplateVar.setTo('#dapp-form-helper-iframe', 'MainRenderTemplate', `popupWindows_${templateName}`);
+    TemplateVar.setTo('#generic-body', 'MainRenderTemplate', `popupWindows_${templateName}`);
 });
 
 Template.body.helpers({

--- a/interface/client/templates/index.js
+++ b/interface/client/templates/index.js
@@ -4,12 +4,17 @@ Template Controllers
 @module Templates
 */
 
-/**
+/**a
 The body template
 
 @class [template] body
 @constructor
 */
+
+// Generic windows reuse windows by switching the template
+ipc.on('uiAction_switchTemplate', (e, templateName) => {
+    TemplateVar.setTo('#dapp-form-helper-iframe', 'MainRenderTemplate', `popupWindows_${templateName}`);
+});
 
 Template.body.helpers({
     /**
@@ -18,6 +23,10 @@ Template.body.helpers({
     @method renderApp
     */
     'renderApp': function () {
+        // Generic windows return the TemplateVar if set in the ipc call above
+        const template = TemplateVar.get('MainRenderTemplate');
+        if (template) { return template; }
+
         if (_.isEmpty(location.hash)) {
             $('title').text('Mist');
             return 'layout_main';

--- a/interface/client/templates/popupWindows/generic.html
+++ b/interface/client/templates/popupWindows/generic.html
@@ -1,0 +1,4 @@
+<template name="popupWindows_generic">
+    <div class="row popup-windows generic">
+    </div>
+</template>

--- a/interface/client/templates/popupWindows/generic.js
+++ b/interface/client/templates/popupWindows/generic.js
@@ -8,7 +8,7 @@ Template Controllers
 /**
 The about template
 
-@class [template] popupWindows_about
+@class [template] popupWindows_generic
 @constructor
 */
 Template['popupWindows_generic'].onCreated(function () {

--- a/interface/client/templates/popupWindows/generic.js
+++ b/interface/client/templates/popupWindows/generic.js
@@ -1,0 +1,17 @@
+/**
+Template Controllers
+
+@module Templates
+*/
+
+
+/**
+The about template
+
+@class [template] popupWindows_about
+@constructor
+*/
+Template['popupWindows_generic'].onCreated(function () {
+
+});
+

--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ const windowStateKeeper = require('electron-window-state');
 const log = logger.create('main');
 
 import configureReduxStore from './modules/core/store';
-import { closeWindow, openWindow, quitApp } from './modules/core/ui/actions';
+import { quitApp } from './modules/core/ui/actions';
 import { setLanguageOnMain } from './modules/core/settings/actions';
 
 Q.config({
@@ -77,14 +77,10 @@ process.on('uncaughtException', (error) => {
 });
 
 // Quit when all windows are closed.
-app.on('window-all-closed', () => {
-    store.dispatch(quitApp());
-});
+app.on('window-all-closed', () => store.dispatch(quitApp()));
 
 // Listen to custom protocol incoming messages, needs registering of URL schemes
-app.on('open-url', (e, url) => {
-    log.info('Open URL', url);
-});
+app.on('open-url', (e, url) => log.info('Open URL', url));
 
 
 let killedSocketsAndNodes = false;
@@ -334,10 +330,7 @@ onReady = () => {
                 return new Q((resolve, reject) => {
                     const onboardingWindow = Windows.createPopup('onboardingScreen');
 
-                    onboardingWindow.on('closed', () => {
-                        store.dispatch(closeWindow('onboarding'));
-                        store.dispatch(quitApp());
-                    });
+                    onboardingWindow.on('closed', () => store.dispatch(quitApp()));
 
                     // change network types (mainnet, testnet)
                     ipcMain.on('onBoarding_changeNet', (e, testnet) => {
@@ -362,7 +355,6 @@ onReady = () => {
                         // prevent that it closes the app
                         onboardingWindow.removeAllListeners('closed');
                         onboardingWindow.close();
-                        store.dispatch(closeWindow('onboarding'));
 
                         ipcMain.removeAllListeners('onBoarding_changeNet');
                         ipcMain.removeAllListeners('onBoarding_launchApp');
@@ -408,21 +400,13 @@ startMainWindow = () => {
     log.info(`Loading Interface at ${global.interfaceAppUrl}`);
 
     mainWindow.on('ready', () => {
-        if (splashWindow) {
-            splashWindow.close();
-            store.dispatch(closeWindow('splash'));
-        }
-
+        if (splashWindow) { splashWindow.close(); }
         mainWindow.show();
-        store.dispatch(openWindow('main'));
     });
 
     mainWindow.load(global.interfaceAppUrl);
 
-    // close app, when the main window is closed
-    mainWindow.on('closed', () => {
-        store.dispatch(quitApp());
-    });
+    mainWindow.on('closed', () => store.dispatch(quitApp()));
 
     // observe Tabs for changes and refresh menu
     const Tabs = global.db.getCollection('UI_tabs');

--- a/modules/core/ui/actions.js
+++ b/modules/core/ui/actions.js
@@ -11,3 +11,19 @@ export function quitApp() {
         }
     }
 }
+
+export function openWindow(windowType) {
+    return { type: '[MAIN]:WINDOW:OPEN', payload: { windowType } };
+}
+
+export function closeWindow(windowType) {
+    return { type: '[MAIN]:WINDOW:CLOSE', payload: { windowType } };
+}
+
+export function reuseGenericWindow(actingType) {
+    return { type: '[MAIN]:GENERIC_WINDOW:REUSE', payload: { actingType } };
+}
+
+export function resetGenericWindow(actingType) {
+    return { type: '[MAIN]:GENERIC_WINDOW:RESET' };
+}

--- a/modules/core/ui/actions.js
+++ b/modules/core/ui/actions.js
@@ -24,6 +24,6 @@ export function reuseGenericWindow(actingType) {
     return { type: '[MAIN]:GENERIC_WINDOW:REUSE', payload: { actingType } };
 }
 
-export function resetGenericWindow(actingType) {
+export function resetGenericWindow() {
     return { type: '[MAIN]:GENERIC_WINDOW:RESET' };
 }

--- a/modules/core/ui/reducer.js
+++ b/modules/core/ui/reducer.js
@@ -1,45 +1,39 @@
 export const initialState = {
-    aboutWindowCreated: false,
     appQuit: false,
-    clientUpdateAvailableWindowCreated: false,
-    connectAccountWindowCreated: false,
-    importAccountWindowCreated: false,
-    loadingWindowCreated: false,
-    mainWindowCreated: false,
-    mainWindowVisible: false,
-    onboardingScreenWindowCreated: false,
-    onboardingScreenWindowVisible: false,
-    remixWindowCreated: false,
-    requestAccountWindowCreated: false,
-    sendTransactionConfirmationWindowCreated: false,
-    splashWindowCreated: false,
-    splashWindowVisible: false,
-    updateAvailableWindowCreated: false,
+    genericWindowActingType: '',
     windowsInit: false,
+    windowsOpen: [],
 };
 
 const ui = (state = initialState, action) => {
     switch (action.type) {
         case '[MAIN]:APP_QUIT:SUCCESS':
             return Object.assign({}, state, { appQuit: true });
-        case 'MAIN_WINDOW::CLOSE':
-            return Object.assign({}, state, { mainWindowVisible: false });
+        case '[MAIN]:WINDOW:OPEN':
+            // TODO: make this list unique
+            return Object.assign({}, state, {
+                windowsOpen: state.windowsOpen.concat(action.payload.windowType)
+            });
+        case '[MAIN]:WINDOW:CLOSE':
+            return Object.assign({}, state, {
+                windowsOpen: state.windowsOpen.filter(w => {
+                    return w !== action.payload.windowType;
+                })
+            });
         case '[MAIN]:WINDOW:CREATE_FINISH':
-            return Object.assign({}, state, { [`${action.payload.type}WindowCreated`]: true });
-        case 'MAIN_WINDOW::SHOW':
-            return Object.assign({}, state, { mainWindowVisible: true });
-        case 'MAIN_WINDOW::HIDE':
-            return Object.assign({}, state, { mainWindowVisible: false });
-        case 'ONBOARDING_WINDOW::CLOSE':
-            return Object.assign({}, state, { onboardingScreenWindowVisible: false });
-        case 'SPLASH_WINDOW::CLOSE':
-            return Object.assign({}, state, { splashWindowVisible: false });
-        case 'SPLASH_WINDOW::SHOW':
-            return Object.assign({}, state, { splashWindowVisible: true });
-        case 'SPLASH_WINDOW::HIDE':
-            return Object.assign({}, state, { splashWindowVisible: false });
+            return Object.assign({}, state, { 
+                [`${action.payload.type}WindowCreated`]: true 
+            });
         case '[MAIN]:WINDOWS:INIT_FINISH':
             return Object.assign({}, state, { windowsInit: true });
+        case '[MAIN]:GENERIC_WINDOW:REUSE':
+            return Object.assign({}, state, {
+                genericWindowActingType: action.payload.actingType,
+            });
+        case '[MAIN]:GENERIC_WINDOW:RESET':
+            return Object.assign({}, state, {
+                genericWindowActingType: '',
+            });
         default:
             return state;
     }

--- a/modules/core/ui/reducer.js
+++ b/modules/core/ui/reducer.js
@@ -1,3 +1,5 @@
+import uniq from 'lodash/uniq';
+
 export const initialState = {
     appQuit: false,
     genericWindowActingType: '',
@@ -10,29 +12,26 @@ const ui = (state = initialState, action) => {
         case '[MAIN]:APP_QUIT:SUCCESS':
             return Object.assign({}, state, { appQuit: true });
         case '[MAIN]:WINDOW:OPEN':
-            // TODO: make this list unique
             return Object.assign({}, state, {
-                windowsOpen: state.windowsOpen.concat(action.payload.windowType)
+                windowsOpen: uniq(state.windowsOpen.concat(action.payload.windowType)),
             });
         case '[MAIN]:WINDOW:CLOSE':
             return Object.assign({}, state, {
                 windowsOpen: state.windowsOpen.filter(w => {
                     return w !== action.payload.windowType;
-                })
-            });
-        case '[MAIN]:WINDOW:CREATE_FINISH':
-            return Object.assign({}, state, { 
-                [`${action.payload.type}WindowCreated`]: true 
+                }),
             });
         case '[MAIN]:WINDOWS:INIT_FINISH':
             return Object.assign({}, state, { windowsInit: true });
         case '[MAIN]:GENERIC_WINDOW:REUSE':
             return Object.assign({}, state, {
                 genericWindowActingType: action.payload.actingType,
+                windowsOpen: state.windowsOpen.concat('generic'),
             });
         case '[MAIN]:GENERIC_WINDOW:RESET':
             return Object.assign({}, state, {
                 genericWindowActingType: '',
+                windowsOpen: state.windowsOpen.filter(i => i !== 'generic'),
             });
         default:
             return state;

--- a/modules/ipc/methods/eth_sendTransaction.js
+++ b/modules/ipc/methods/eth_sendTransaction.js
@@ -59,7 +59,7 @@ module.exports = class extends BaseProcessor {
 
             BlurOverlay.enable();
 
-            modalWindow.on('closed', () => {
+            modalWindow.on('hidden', () => {
                 BlurOverlay.disable();
 
                 // user cancelled?
@@ -69,8 +69,7 @@ module.exports = class extends BaseProcessor {
             });
 
             ipc.once('backendAction_unlockedAccountAndSentTransaction', (ev, err, result) => {
-                if (Windows.getById(ev.sender.id) === modalWindow
-                        && !modalWindow.isClosed) {
+                if (Windows.getById(ev.sender.id) === modalWindow && !modalWindow.isClosed) {
                     if (err || !result) {
                         this._log.debug('Confirmation error', err);
 

--- a/modules/ipcCommunicator.js
+++ b/modules/ipcCommunicator.js
@@ -77,17 +77,20 @@ ipc.on('backendAction_windowMessageToOwner', (e, error, value) => {
     const windowId = e.sender.id;
     const senderWindow = Windows.getById(windowId);
 
+    // If msg is from a generic window, use the "actingType" instead of type
+    const senderWindowType = senderWindow.actingType || senderWindow.type;
+
     if (senderWindow.ownerId) {
         const ownerWindow = Windows.getById(senderWindow.ownerId);
         const mainWindow = Windows.getByType('main');
 
         if (ownerWindow) {
-            ownerWindow.send('uiAction_windowMessage', senderWindow.type, error, value);
+            ownerWindow.send('uiAction_windowMessage', senderWindowType, error, value);
         }
 
         // send through the mainWindow to the webviews
         if (mainWindow) {
-            mainWindow.send('uiAction_windowMessage', senderWindow.type, senderWindow.ownerId, error, value);
+            mainWindow.send('uiAction_windowMessage', senderWindowType, senderWindow.ownerId, error, value);
         }
     }
 });

--- a/modules/preloader/mistUI.js
+++ b/modules/preloader/mistUI.js
@@ -58,11 +58,8 @@ delete window.require;
 
 // A message coming from other window, to be passed to a webview
 ipcRenderer.on('uiAction_windowMessage', (e, type, id, error, value) => {
-    console.log(type, id, error, value);
     if ((type === 'requestAccount') || (type === 'connectAccount') && !error) {
-        Tabs.update({ webviewId: id }, { $addToSet: {
-            'permissions.accounts': value,
-        } });
+        Tabs.update({ webviewId: id }, { $addToSet: { 'permissions.accounts': value } });
     }
 
     // forward to the webview (TODO: remove and manage in the ipcCommunicator?)
@@ -73,7 +70,6 @@ ipcRenderer.on('uiAction_windowMessage', (e, type, id, error, value) => {
             webview.send('uiAction_windowMessage', type, error, value);
         }
     }
-
 });
 
 ipcRenderer.on('uiAction_enableBlurOverlay', (e, value) => {

--- a/modules/preloader/splashScreen.js
+++ b/modules/preloader/splashScreen.js
@@ -16,3 +16,6 @@ window.ipc = ipcRenderer;
 window.mist = mist();
 window.mistMode = remote.getGlobal('mode');
 window.dirname = remote.getGlobal('dirname');
+
+// Stub out the Redux store
+window.store = { dispatch: () => {} };

--- a/modules/windows.js
+++ b/modules/windows.js
@@ -2,7 +2,12 @@ const { app, BrowserWindow, ipcMain: ipc } = require('electron');
 const Settings = require('./settings');
 const log = require('./utils/logger').create('Windows');
 const EventEmitter = require('events').EventEmitter;
-import { resetGenericWindow, reuseGenericWindow } from './core/ui/actions';
+import {
+    closeWindow,
+    openWindow,
+    resetGenericWindow,
+    reuseGenericWindow,
+} from './core/ui/actions';
 
 class GenericWindow extends EventEmitter {
     constructor(mgr) {
@@ -189,6 +194,7 @@ class Window extends EventEmitter {
             this.isContentReady = false;
 
             this.emit('closed');
+            store.dispatch(closeWindow(this.type));
         });
 
         this.window.once('close', (e) => {
@@ -255,6 +261,8 @@ class Window extends EventEmitter {
         this.window.show();
 
         this.isShown = true;
+
+        store.dispatch(openWindow(this.type));
     }
 
 
@@ -284,6 +292,11 @@ class Windows {
 
         this.loading.on('show', () => {
             this.loading.window.center();
+            store.dispatch(openWindow('loading'));
+        });
+
+        this.loading.on('hide', () => {
+            store.dispatch(closeWindow('loading'));
         });
 
         // when a window gets initalized it will send us its id

--- a/modules/windows.js
+++ b/modules/windows.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, ipcMain: ipc } = require('electron');
 const Settings = require('./settings');
 const log = require('./utils/logger').create('Windows');
 const EventEmitter = require('events').EventEmitter;
+import { resetGenericWindow, reuseGenericWindow } from './core/ui/actions';
 
 class GenericWindow extends EventEmitter {
     constructor(mgr) {
@@ -69,6 +70,7 @@ class GenericWindow extends EventEmitter {
         this.actingType = null;
         this.isAvailable = true;
         this.emit('hidden');
+        store.dispatch(resetGenericWindow());
     }
 
     show() {
@@ -100,6 +102,7 @@ class GenericWindow extends EventEmitter {
         this.window.setSize(options.electronOptions.width, options.electronOptions.height);
         this.send('uiAction_switchTemplate', type);
         this.show();
+        store.dispatch(reuseGenericWindow(type));
     }
 }
 
@@ -310,7 +313,7 @@ class Windows {
     }
 
     create(type, opts, callback) {
-        global.store.dispatch({ type: '[MAIN]:WINDOW:CREATE_START', payload: { type } });
+        store.dispatch({ type: '[MAIN]:WINDOW:CREATE_START', payload: { type } });
 
         const options = _.deepExtend(this.getDefaultOptionsForType(type), opts || {});
 
@@ -333,7 +336,7 @@ class Windows {
             wnd.callback = callback;
         }
 
-        global.store.dispatch({ type: '[MAIN]:WINDOW:CREATE_FINISH', payload: { type } });
+        store.dispatch({ type: '[MAIN]:WINDOW:CREATE_FINISH', payload: { type } });
 
         return wnd;
     }

--- a/modules/windows.js
+++ b/modules/windows.js
@@ -591,6 +591,12 @@ class Windows {
         if (genericWindow && genericWindow.isAvailable) {
             genericWindow.reuse(type, opts, callback);
             return genericWindow;
+        } else if (genericWindow) {
+            // If a generic window exists of the same actingType, focus that window
+            if (genericWindow.actingType === type) {
+                genericWindow.webContents.focus();
+                return genericWindow;
+            }
         }
 
         this.loading.show();

--- a/tests/unit/core/ui/reducer.test.js
+++ b/tests/unit/core/ui/reducer.test.js
@@ -6,18 +6,6 @@ describe('the ui reducer', () => {
         assert.deepEqual(reducer(undefined, {}), initialState);
     });
 
-    it('should handle the "[MAIN]:WINDOW:CREATE_FINISH" action', () => {
-        const action = {
-            type: '[MAIN]:WINDOW:CREATE_FINISH',
-            payload: { type: 'about' }
-        };
-        const expectedState = Object.assign({}, initialState, {
-            aboutWindowCreated: true,
-        });
-
-        assert.deepEqual(reducer(initialState, action), expectedState);
-    });
-
     it('should handle the "[MAIN]:APP_QUIT:SUCCESS" action', () => {
         const action = { type: '[MAIN]:APP_QUIT:SUCCESS' };
         const expectedState = Object.assign({}, initialState, {
@@ -63,7 +51,8 @@ describe('the ui reducer', () => {
             payload: { actingType: 'about' },
         };
         const expectedState = Object.assign({}, initialState, {
-            genericWindowActingType: 'about'
+            genericWindowActingType: 'about',
+            windowsOpen: ['generic'],
         });
 
         assert.deepEqual(reducer(initialState, action), expectedState);
@@ -72,9 +61,13 @@ describe('the ui reducer', () => {
     it('should handle the "[MAIN]:GENERIC_WINDOW:RESET" action', () => {
         const state = Object.assign({}, initialState, {
             genericWindowActingType: 'about',
+            windowsOpen: ['generic', 'main'],
         });
         const action = { type: '[MAIN]:GENERIC_WINDOW:RESET' };
+        const expectedState = Object.assign({}, initialState, {
+            windowsOpen: ['main'],
+        });
 
-        assert.deepEqual(reducer(state, action), initialState);
+        assert.deepEqual(reducer(state, action), expectedState);
     });
 });

--- a/tests/unit/core/ui/reducer.test.js
+++ b/tests/unit/core/ui/reducer.test.js
@@ -26,4 +26,55 @@ describe('the ui reducer', () => {
 
         assert.deepEqual(reducer(initialState, action), expectedState);
     });
+
+    it('should handle the "[MAIN]:WINDOW:OPEN" action', () => {
+        const state = Object.assign({}, initialState, {
+            windowsOpen: ['about']
+        });
+        const action = {
+            type: '[MAIN]:WINDOW:OPEN',
+            payload: { windowType: 'onboarding' },
+        };
+        const expectedState = Object.assign({}, state, {
+            windowsOpen: ['about', 'onboarding']
+        });
+
+        assert.deepEqual(reducer(state, action), expectedState);
+    });
+
+    it('should handle the "[MAIN]:WINDOW:CLOSE" action', () => {
+        const state = Object.assign({}, initialState, {
+            windowsOpen: ['about', 'onboarding']
+        });
+        const action = {
+            type: '[MAIN]:WINDOW:CLOSE',
+            payload: { windowType: 'onboarding' },
+        };
+        const expectedState = Object.assign({}, state, {
+            windowsOpen: ['about']
+        });
+
+        assert.deepEqual(reducer(state, action), expectedState);
+    });
+
+    it('should handle the "[MAIN]:GENERIC_WINDOW:REUSE" action', () => {
+        const action = {
+            type: '[MAIN]:GENERIC_WINDOW:REUSE',
+            payload: { actingType: 'about' },
+        };
+        const expectedState = Object.assign({}, initialState, {
+            genericWindowActingType: 'about'
+        });
+
+        assert.deepEqual(reducer(initialState, action), expectedState);
+    });
+
+    it('should handle the "[MAIN]:GENERIC_WINDOW:RESET" action', () => {
+        const state = Object.assign({}, initialState, {
+            genericWindowActingType: 'about',
+        });
+        const action = { type: '[MAIN]:GENERIC_WINDOW:RESET' };
+
+        assert.deepEqual(reducer(state, action), initialState);
+    });
 });


### PR DESCRIPTION
#### What does it do?
Refactors the use of electron browser windows for better performance.
#### Any helpful background information?
- Meteor startup times appear to be the biggest detractor from performance within the app, specifically when opening any new window. This refactor introduces a reusable ("generic") window for popup windows to use if it's available.
- At the moment, the generic window has web3 capabilities by default, given the use of preloaders and the uncertainty of what the window will be used for. If this is too great a security risk, a future iteration can introduce a second generic window for use with popups that don't require web3.
- There's only one generic window for now. If multiple popups are opened, the existing implementation takes over (loading window, then new Meteor app).
#### Which code should the reviewer start with?
`windows.js` is the bulk of it. There's a comment trail along the way.
#### Screenshots
Redux tracked state:
![screen shot 2017-11-14 at 9 23 49 am](https://user-images.githubusercontent.com/3621728/32797813-23e69dde-c930-11e7-91c7-24a60aad2358.png)
