### PR TITLE
update solc to 0.4.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "oboe": "^2.1.3",
     "os-timesync": "^1.0.8",
     "semver": "^5.1.0",
-    "solc": "^0.4.15",
+    "solc": "^0.4.18",
     "swarm-js": "^0.1.21",
     "typescript": "^2.2.2",
     "underscore": "^1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4676,9 +4676,9 @@ sntp@2.x.x:
   dependencies:
     hoek "4.x.x"
 
-solc@^0.4.15:
-  version "0.4.16"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.16.tgz#809a5b1257c7c200e11a841b377eaec274698539"
+solc@^0.4.18:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.4.18.tgz#83ac6d871dd16a9710e67dbb76dad7f614100702"
   dependencies:
     fs-extra "^0.30.0"
     memorystream "^0.3.1"


### PR DESCRIPTION
I'm eager for 0.4.18 since it has the memory byte array fix.