### PR TITLE
Auto-generating SHA256 checksums

### DIFF
--- a/gulpTasks/publishing.js
+++ b/gulpTasks/publishing.js
@@ -21,16 +21,11 @@ gulp.task('checksums', (cb) => {
     let command;
     let argument = '';
 
-    switch (process.platform) {
-    case 'darwin':
-        command = 'md5';
-        break;
-    case 'win32':
+    if (process.platform === 'win32') {
         command = 'certUtil -hashfile';
-        argument = 'md5';
-        break;
-    default:
-        command = 'md5sum';
+        argument = 'SHA256';
+    } else {
+        command = 'shasum -a 256';
     }
 
     files.forEach((file) => {
@@ -90,14 +85,22 @@ gulp.task('upload-binaries', (cb) => {
             })
             // append checksums to draft text
             .then(() => {
+                console.info('Appending checksums to release notes...', checksums);
                 if (draft.body && checksums) {
                     got.patch(`https://api.github.com/repos/ethereum/mist/releases/${draft.id}?access_token=${GITHUB_TOKEN}`, {
                         body: JSON.stringify({
                             tag_name: `v${version}`,
-                            body: `${draft.body}\n\n## Checksums\n\`\`\`\n${checksums.join('')}\`\`\``
+                            // String manipulation to create a checksums table
+                            body: String.concat('File | Checksum (SHA256)\n-- | --', checksums.map((e) => {
+                                const line = e.replace('\n', '').split('  ');
+                                return `${line[1]} | ${line[0]}`;
+                            }).join('\n'))
                         })
                     });
                 }
+            })
+            .catch((err) => {
+                console.log(err);
             });
         }
     })

--- a/gulpTasks/publishing.js
+++ b/gulpTasks/publishing.js
@@ -93,7 +93,7 @@ gulp.task('upload-binaries', (cb) => {
                             // String manipulation to create a checksums table
                             body: String.concat('File | Checksum (SHA256)\n-- | --', checksums.map((e) => {
                                 const line = e.replace('\n', '').split('  ');
-                                return `${line[1]} | ${line[0]}`;
+                                return `<sub>${line[1]}</sub> | <sub>\`${line[0]}\`</sub>`;
                             }).join('\n'))
                         })
                     });


### PR DESCRIPTION
#### What does it do?
It runs sha256 against Mist/EW artifacts and appends them to the release notes if there are any release drafts.

#### Any helpful background information?
We used to distribute binaries with MD5 checksums. SHA-256 checksums were generated manually until now. 

#### Which code should the reviewer start with?
-

#### New dependencies? What are they used for?
No.

#### Relevant screenshots?
This is what we aim for. We can't ensure what order the builds will finish, so it still requires a little text manipulation at the end, as all builds will print out the table header as well.

![image](https://user-images.githubusercontent.com/47108/32862033-b5539c64-ca24-11e7-9a51-a52c81c1dff0.png)
