### PR TITLE
Make individual text selectable in popup

### DIFF
--- a/interface/client/styles/popupWindows.import.less
+++ b/interface/client/styles/popupWindows.import.less
@@ -76,7 +76,8 @@
 	}
 
 	&.update-available {
-        -webkit-user-select: all;
+        -webkit-user-select: auto;
+        user-select: auto;
 
 		.text {
 			text-align: left;


### PR DESCRIPTION
#### What does it do?

Make individual text selectable in the popup-window, for example to copy the checksum of an update.

#### Any helpful background information?

See issue https://github.com/ethereum/mist/issues/3384