### PR TITLE
Upgrade electron-builder to 19.49.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "del": "^2.2.2",
     "ecstatic": "^2.1.0",
     "electron": "1.7.9",
-    "electron-builder": "^12.2.2",
+    "electron-builder": "^19.49.0",
     "eslint": "^3.14.1",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
My mac running High Sierra was getting stuck on building/generating the binaries. Upgrading electron-builder fixed it.