### PR TITLE
Upgrade electron-builder to 19.49.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
             - graphicsmagick
             - xz-utils
             - nsis
+            - g++-multilib
           sources:
             - mono
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ matrix:
 install:
   - echo $PATH
   - PATH=$PATH:$HOME/.meteor && curl -L https://raw.githubusercontent.com/arunoda/travis-ci-meteor-packages/1390e0f96162d0d70fc1e60a6b0f4f891a0e8f42/configure.sh | /bin/sh
+  - export PATH=$PATH:`yarn global bin`
   - yarn global add gulp-cli meteor-build-client
   - yarn
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "del": "^2.2.2",
     "ecstatic": "^2.1.0",
     "electron": "1.7.9",
-    "electron-builder": "^12.2.2",
+    "electron-builder": "^19.49.0",
     "eslint": "^3.14.1",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
My mac running High Sierra was getting stuck on building/generating the binaries. Upgrading electron-builder fixed it.