### PR TITLE
Fix for mist.es.i18n.json

### DIFF
--- a/interface/i18n/mist.es.i18n.json
+++ b/interface/i18n/mist.es.i18n.json
@@ -27,7 +27,7 @@
                 "default": "Default"
             },
             "file": {
-                "label": "Arquivo",
+                "label": "Archivo",
                 "importPresale": "Importar Cuentas",
                 "newAccount": "Nueva cuenta",
                 "backup": "Copia de seguridad",


### PR DESCRIPTION
#### What does it do?
Fixed spanish translation for File

#### Any helpful background information?
Arquivo is not a spanish word at least according to RAE. The right word for File translation is Archivo.

#### Which code should the reviewer start with?
Not Applicable

#### New dependencies? What are they used for?
Not Applicable

#### Relevant screenshots?
Not Applicable
