### PR TITLE
Retry logic

### DIFF
--- a/interface/client/styles/splashScreen.import.less
+++ b/interface/client/styles/splashScreen.import.less
@@ -26,7 +26,8 @@
         h1 {
             color: #fff;
         }
-        button.start-app {
+        button.start-app,
+        button.retry-connection {
             color: #BCD3E6;
             &:hover {
                 color: darken(#BCD3E6, 5%);
@@ -88,7 +89,8 @@
         color: rgba(255,255,255, 0.8);
     }
     /* start app button */
-    button.start-app {
+    button.start-app,
+    button.retry-connection {
         bottom: 10px;
         right: 0;
         left: 0;
@@ -102,7 +104,8 @@
         font-size: 1em;
         font-weight: bold;
     }
-    button.start-app:hover {
+    button.start-app:hover,
+    button.retry-connection:hover {
         color: #2A6ED0;
     }
 

--- a/interface/client/templates/popupWindows/splashScreen.html
+++ b/interface/client/templates/popupWindows/splashScreen.html
@@ -6,10 +6,10 @@
 
         {{#if TemplateVar.get "showStartAppButton"}}
             <button class="start-app">{{{TemplateVar.get "startAppButtonText"}}}</button>
-        {{/if}}
-
-        {{#if TemplateVar.get "showRetryConnectionButton"}}
-            <button class="retry-connection">{{{TemplateVar.get "retryConnectionButtonText"}}}</button>
+        {{else}}
+            {{#if TemplateVar.get "showRetryConnectionButton"}}
+                <button class="retry-connection">{{{TemplateVar.get "retryConnectionButtonText"}}}</button>
+            {{/if}}
         {{/if}}
 
         <img id="image" src="{{appIconPath}}">

--- a/interface/client/templates/popupWindows/splashScreen.html
+++ b/interface/client/templates/popupWindows/splashScreen.html
@@ -8,6 +8,10 @@
             <button class="start-app">{{{TemplateVar.get "startAppButtonText"}}}</button>
         {{/if}}
 
+        {{#if TemplateVar.get "showRetryConnectionButton"}}
+            <button class="retry-connection">{{{TemplateVar.get "retryConnectionButtonText"}}}</button>
+        {{/if}}
+
         <img id="image" src="{{appIconPath}}">
         <h1>
             {{{TemplateVar.get "text"}}}

--- a/interface/client/templates/popupWindows/splashScreen.js
+++ b/interface/client/templates/popupWindows/splashScreen.js
@@ -39,6 +39,7 @@ Template['popupWindows_splashScreen'].onCreated(function () {
         TemplateVar.set(template, 'showNetworkIndicator', status === 'done');
         TemplateVar.set(template, 'showProgressBar', false);
         TemplateVar.set(template, 'showStartAppButton', false);
+        TemplateVar.set(template, 'showRetryConnectionButton', false);
         TemplateVar.set(template, 'logText', null);
     });
 
@@ -51,6 +52,7 @@ Template['popupWindows_splashScreen'].onCreated(function () {
             TemplateVar.set(template, 'logText', null);
             TemplateVar.set(template, 'showProgressBar', false);
             TemplateVar.set(template, 'showStartAppButton', false);
+            TemplateVar.set(template, 'showRetryConnectionButton', false);
             break;
 
         case 'started':
@@ -80,6 +82,8 @@ Template['popupWindows_splashScreen'].onCreated(function () {
             errorTag = 'mist.startScreen.' + (errorTag || 'nodeError');
 
             TemplateVar.set(template, 'text', TAPi18n.__(errorTag));
+            TemplateVar.set(template, 'showRetryConnectionButton', true);
+            TemplateVar.set(template, 'retryConnectionButtonText', TAPi18n.__('mist.startScreen.retryConnection'));
             break;
         }
     });
@@ -254,5 +258,9 @@ Template['popupWindows_splashScreen'].helpers({
 Template['popupWindows_splashScreen'].events({
     'click .start-app': function () {
         ipc.send('backendAction_skipSync');
+    },
+
+    'click .retry-connection': function () {
+        ipc.send('retryConnection');
     }
 });

--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -163,6 +163,7 @@
             "nodeSyncFoundPeers": "Connecting to __peers__ peers...",
             "peerSearchTimeout": "Skip peer search",
             "launchApp": "Launch Application",
+            "retryConnection": "Retry Connection",
             "clientBinaries": {
                 "scanning": "Checking for node update...",
                 "downloading": "Downloading new node...",

--- a/main.js
+++ b/main.js
@@ -221,6 +221,12 @@ onReady = () => {
 
 
     const kickStart = () => {
+        // connection failed; retry
+        ipcMain.on('retryConnection', () => {
+            kickStart();
+        });
+
+        // client binary stuff
         ClientBinaryManager.on('status', (status, data) => {
             Windows.broadcast('uiAction_clientBinaryStatus', status, data);
         });


### PR DESCRIPTION
#### What does it do?
Tweaks #3169 
- rebases on `develop`
- prevents overlapping action items on the splashWindow