### PR TITLE
Update os-timesync to fix new timedatectl output

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "minimongo-standalone": "^1.1.0-3",
     "numeral": "^2.0.6",
     "oboe": "^2.1.3",
-    "os-timesync": "^1.0.8",
+    "os-timesync": "^1.0.9",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "remote-redux-devtools": "^0.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4390,9 +4390,9 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-timesync@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/os-timesync/-/os-timesync-1.0.8.tgz#390ae8832e20183ea3fc1b97ea90bcbc97c0178f"
+os-timesync@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/os-timesync/-/os-timesync-1.0.9.tgz#5e7235f08d618658ae83793a8f7650a390073614"
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"


### PR DESCRIPTION
#### What does it do?
Bumps os-timesync package to new version

#### Any helpful background information?
`systemd` component `timedatectl` changed output style and I am keep getting pop up that tells me to install `ntp`.

Related commit in os-timesync: https://github.com/fjl/os-timesync/commit/c4c1fab0335db9ac75885c02a498c274d83d4815