### PR TITLE
Adding unit tests to Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,9 @@ script:
   # windows code-signing on master branch
   - if [[ $GULP_PLATFORM == "win" && $TRAVIS_BRANCH == "master" ]]; then export CSC_LINK=$CSC_WIN_LINK && CSC_KEY_PASSWORD=$CSC_WIN_KEY_PASSWORD; fi
 
+  # unit test
+  - if [[ $GULP_PLATFORM == "linux" ]]; then yarn test:unit:once; fi
+    
   # build mist
   - if [[ $GULP_PLATFORM == "mac" ]]; then travis_wait 60 gulp --$GULP_PLATFORM; fi  # increase timeout for slower mac builds
   - if [[ $GULP_PLATFORM != "mac" ]]; then gulp --$GULP_PLATFORM; fi

--- a/tests/unit/core/ui/actions.test.js
+++ b/tests/unit/core/ui/actions.test.js
@@ -17,7 +17,7 @@ describe('ui actions:', () => {
             const actions = store.getActions();
 
             assert.equal(actions.length, 2);
-            assert.equal(actions[0].type, '[MAIN]:APP_QUIT:START');
+            assert.equal(actions[0].type, '[MAIN]:APP_QUIT:FORCE_ERROR');
         });
     });
 });

--- a/tests/unit/core/ui/actions.test.js
+++ b/tests/unit/core/ui/actions.test.js
@@ -17,7 +17,7 @@ describe('ui actions:', () => {
             const actions = store.getActions();
 
             assert.equal(actions.length, 2);
-            assert.equal(actions[0].type, '[MAIN]:APP_QUIT:FORCE_ERROR');
+            assert.equal(actions[0].type, '[MAIN]:APP_QUIT:START');
         });
     });
 });


### PR DESCRIPTION
#### What does it do?

It runs `yarn test:unit:once` in Travis jobs.

#### Any helpful background information?

It should only run on Linux builds and its return codes must be correct (non-zero for errors and zero for success)
