### PR TITLE
Updating win64 checksum

### DIFF
--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -72,7 +72,7 @@
                         "download": {
                             "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.8.2-b8b9f7f4.zip",
                             "type": "zip",
-                            "md5": "3080558f77ea924596379d15b3df5dcd",
+                            "md5": "f498df54aaa42f4269c2d2d06df482fd",
                             "bin": "geth-windows-amd64-1.8.2-b8b9f7f4\\geth.exe"
                         },
                         "bin": "geth.exe",

--- a/clientBinaries.json
+++ b/clientBinaries.json
@@ -92,7 +92,7 @@
                         "download": {
                             "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.8.2-b8b9f7f4.zip",
                             "type": "zip",
-                            "md5": "cf97e20d63c89f2d141d88ef11f3951b",
+                            "md5": "4760b54e20de3ee50237ea8df896fb6f",
                             "bin": "geth-windows-386-1.8.2-b8b9f7f4\\geth.exe"
                         },
                         "bin": "geth.exe",


### PR DESCRIPTION
Geth checksums for Windows 32 and 64 haven't in the latest `clientBinaries.json` updated. Meaning, its checksums were, in fact, related to the previous Geth version, 1.8.1.

This PR fixes #3730.