### PR TITLE
Bump electron to 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "co-mocha": "^1.2.0",
     "del": "^3.0.0",
     "ecstatic": "^2.1.0",
-    "electron": "1.8.2",
+    "electron": "1.8.3",
     "electron-builder": "^20.0.8",
     "eslint": "^3.14.1",
     "eslint-config-airbnb-base": "^11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,9 +1952,9 @@ electron-window-state@^4.0.1:
     jsonfile "^2.2.3"
     mkdirp "^0.5.1"
 
-electron@1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.2.tgz#a817cd733c2972b3c7cc4f777caf6e424b88014d"
+electron@1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.3.tgz#001416ea3a25ce594e317cb5531bc41eadd22f7f"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
Updates electron to latest stable. [Release notes](https://github.com/electron/electron/releases/tag/v1.8.3)