### PR TITLE
Re-enable --skipTasks gulpfile CLI option

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,18 +72,19 @@ gulp.task('uploadQueue', (cb) => {
     runSeq.apply(null, _.flatten([tasks, cb]));
 });
 
+const skipTasks = options.skipTasks.replace(/\s/g,'').split(',');
+const tasks = [
+    'clean-dist',
+    'copy-app-source-files',
+    'transpile-main',
+    'transpile-modules',
+    'copy-build-folder-files',
+    'switch-production',
+    'bundling-interface',
+    'copy-i18n',
+    'build-dist',
+    'release-dist',
+    'build-nsis'
+].filter(task => !skipTasks.includes(task));
 
-// tasks
-gulp.task('default', gulp.series(
-        'clean-dist',
-        'copy-app-source-files',
-        'transpile-main',
-        'transpile-modules',
-        'copy-build-folder-files',
-        'switch-production',
-        'bundling-interface',
-        'copy-i18n',
-        'build-dist',
-        'release-dist',
-        'build-nsis',
-));
+gulp.task('default', gulp.series(tasks));


### PR DESCRIPTION
#### What does it do?

The current documentation states that a [`--skipTasks` CLI option](https://github.com/ethereum/mist#skiptasks) can be used to omit specific gulp tasks when executing the default task series, but this option is no longer actually used. It looks like it was unintentionally removed as part of https://github.com/ethereum/mist/commit/740d11311a98d6c56339224fa942e7ebe5868d54, so this PR re-enables this behavior.

#### Any helpful background information?

Previous implementations of the handling of this option relied on a third party library for array filtering and failed when a skipped task list contained spaces. This implementation uses `Array.filter` instead of relying on underscore's `_.difference` method and safely handles whitespace.

#### Which code should the reviewer start with?

[gulpfile.js](https://github.com/ethereum/mist/compare/develop...bitpshr:skipTasks-fix?expand=1#diff-b9e12334e9eafd8341a6107dd98510c9)

#### New dependencies? What are they used for?

N/A

#### Relevant screenshots?

N/A

Resolves #3739 