### PR TITLE
menu: there is no "Accounts" menu anymore

### DIFF
--- a/interface/i18n/mist.ca.i18n.json
+++ b/interface/i18n/mist.ca.i18n.json
@@ -190,7 +190,7 @@
                 "enterPassword": "Introdueix una contrasenya",
                 "repeatPassword": "Repeteix la contrasenya",
                 "creating": "Generant el compte...",
-                "backupHint": "Assegura't que fas una còpia de seguretat dels teus fitxer de claus I contrasenya!\n\nPots trobar el teu fitxer de claus mitjançant el menú principal -> Comptes -> Copia de seguretat -> Comptes. Desa una copia de la carpeta del \"fitxer de claus\" on no puguis perdre-la!",
+                "backupHint": "Assegura't que fas una còpia de seguretat dels teus fitxer de claus I contrasenya!\n\nPots trobar el teu fitxer de claus mitjançant el menú principal -> Fitxer -> Copia de seguretat -> Comptes. Desa una copia de la carpeta del \"fitxer de claus\" on no puguis perdre-la!",
                 "errors": {
                     "passwordMismatch": "Les teves contrasenyes no coincideixen.",
                     "passwordTooShort": "Utilitza una contrasenya més llarga"

--- a/interface/i18n/mist.de.i18n.json
+++ b/interface/i18n/mist.de.i18n.json
@@ -27,7 +27,7 @@
                 "default": "Standard"
             },
             "file": {
-                "label": "Konten",
+                "label": "Datei",
                 "importPresale": "Konto importieren",
                 "newAccount": "Neues Konto",
                 "backup": "Sicherung",
@@ -151,6 +151,7 @@
                 "enterPassword": "Passwort eingeben",
                 "repeatPassword": "Passwort wiederholen",
                 "creating": "Konto wird angelegt...",
+                "backupHint": "Bitte stelle sicher dass du von allen Schlüsseldateien Sicherungen erstellst. Unabhängig davon solltest du dich AUCH vergewissern dass du deine Passwörter nicht vergisst bzw. dass du diese sicher in einem Passwort-Manager abgespeichert hast!\n\nDie verschlüsselten Wallet-Dateien findest du im Hauptmenü -> Datei -> Sicherung -> Konten. Bewahre Kopien des \"keystore\"  Ordners an einem sicheren Ort auf!",
                 "errors": {
                     "passwordMismatch": "Die Passwörter stimmen nicht überein.",
                     "passwordTooShort": "Wähle ein längeres Passwort..."

--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -194,7 +194,7 @@
                 "enterPassword": "Enter password",
                 "repeatPassword": "Repeat password",
                 "creating": "Generating account...",
-                "backupHint": "Make sure you backup your keyfiles AND password!\n\nYou can find your keyfiles folder using the main menu -> Accounts -> Backup -> Accounts. Keep a copy of the \"keystore\" folder where you can't lose it!",
+                "backupHint": "Make sure you backup your keyfiles AND password!\n\nYou can find your keyfiles folder using the main menu -> File -> Backup -> Accounts. Keep a copy of the \"keystore\" folder where you can't lose it!",
                 "errors": {
                     "passwordMismatch": "Your passwords don't match.",
                     "passwordTooShort": "Make a longer password"

--- a/interface/i18n/mist.sq.i18n.json
+++ b/interface/i18n/mist.sq.i18n.json
@@ -13,7 +13,7 @@
                 "quit": "Dil nga __app__"
             },
             "file": {
-                "label": "Llogari",
+                "label": "Skedari",
                 "importPresale": "Merr llogari",
                 "newAccount": "Llogari e re",
                 "backup": "Ruaj kopje rezervë",
@@ -170,7 +170,7 @@
                 "enterPassword": "Fusni fjalëkalimin",
                 "repeatPassword": "Përsërisni fjalëkalimin",
                 "creating": "Duke krijuar llogari...",
-                "backupHint": "Sigurohuni të ruani edhe fjalëkalimin, edhe skedarët çelës!\n\nMund t'i gjeni këta skedarë duke përdorur menunë kryesore -> Llogaritë -> Ruaj kopje rezervë -> Llogaritë. Ruani një kopje të dosjes \"keystore\" në një vend të sigurt!",
+                "backupHint": "Sigurohuni të ruani edhe fjalëkalimin, edhe skedarët çelës!\n\nMund t'i gjeni këta skedarë duke përdorur menunë kryesore -> Skedari -> Ruaj kopje rezervë -> Llogaritë. Ruani një kopje të dosjes \"keystore\" në një vend të sigurt!",
                 "errors": {
                     "passwordMismatch": "Fjalëkalimet nuk përputhen.",
                     "passwordTooShort": "Krijoni një fjalëkalim më të gjatë"


### PR DESCRIPTION
#### What does it do?

The warning about making backups of keystore files was not updated with this change of the "Accounts" menu to a "File" menu, see: https://github.com/zhangkimii/https-github.com-ethereum-mist/commit/65a9fb3213bbf820aaad85cc5bb9a56e9155c855#diff-7412f9723fd3d73999d755e7f3214656R135 , therefore this commit makes sure that the backupHint does not ask the user to click on the "Accounts" menu (which does not exist anymore) but it now correctly mentiones the "File" menu.

#### Any helpful background information?

This commit seems to have introduced the problem:
https://github.com/zhangkimii/https-github.com-ethereum-mist/commit/65a9fb3213bbf820aaad85cc5bb9a56e9155c855

the commit message was "move swarm menu into accounts, rename it into file menu" 

I've tried to make sure that all present backupHint translations are now also reflecting the correct File-menu-label, but unfortunately there are many, many, many translations missing :(
(off-topic: I think you should somehow involve the community to help with translations by making it easy for the contributers/translaters to see which strings are not yet translated or incorrectly translated or just copies from the english text which seems very often to be the case :( . Several translation strings seem to be pretty bad or old.)