### PR TITLE
update italian translation file: mist.it.i18n.json

### DIFF
--- a/interface/i18n/mist.it.i18n.json
+++ b/interface/i18n/mist.it.i18n.json
@@ -19,7 +19,7 @@
                 "backup": "Backup",
                 "backupKeyStore": "Accounts",
                 "backupMist": "Dati applicativi",
-                "swarmUpload": "Carica a Swarm"
+                "swarmUpload": "Carica su Swarm"
             },
             "edit": {
                 "label": "Modifica",
@@ -156,8 +156,8 @@
             "clientBinaries": {
                 "scanning": "Controlla aggiornamento nodo...",
                 "downloading": "Scaricamento nuovo nodo...",
-                "loadConfig": "Caricamento configurazione cliente...",
-                "filtering": "Filtro codice binario del cliente...",
+                "loadConfig": "Caricamento configurazione client...",
+                "filtering": "Filtro codice binario del client...",
                 "done": "Nodo Ethereum aggiornato...",
                 "error": "Errore durante lo scaricamento del codice binario."
             }
@@ -176,7 +176,7 @@
             },
             "requestAccount": {
                 "title": "Crea account",
-                "enterPassword": "Immetti password",
+                "enterPassword": "Inserisci password",
                 "repeatPassword": "Ripeti password",
                 "creating": "Generazione account...",
                 "backupHint": "Assicurati di fare i backup di tutti i file nella cartella \"keystore\". Indipendentemente da ciò, devi ANCHE assicurarti di non dimenticare le tue password o di averle salvate in modo sicuro in un password manager!\n\nI file wallet crittografati possono essere trovati nel menu -> File -> Backup -> Accounts. Conserva multiple copie della cartella \"keystore\" in diversi posti sicuri!",

--- a/interface/i18n/mist.it.i18n.json
+++ b/interface/i18n/mist.it.i18n.json
@@ -12,6 +12,15 @@
                 "showAll": "Mostra tutto",
                 "quit": "Esci da __app__"
             },
+            "file": {
+                "label": "File",
+                "importPresale": "Importa accounts",
+                "newAccount": "Nuovo account",
+                "backup": "Backup",
+                "backupKeyStore": "Accounts",
+                "backupMist": "Dati applicativi",
+                "swarmUpload": "Carica a Swarm"
+            },
             "edit": {
                 "label": "Modifica",
                 "undo": "Annulla",
@@ -24,16 +33,26 @@
             "view": {
                 "label": "Visualizza",
                 "fullscreen": "Schermo intero",
-                "default": "Default"
-            },
-            "file": {
-                "label": "File",
-                "importPresale": "Importa Accounts",
-                "newAccount": "Nuovo account",
-                "backup": "Backup",
-                "backupKeyStore": "Accounts",
-                "backupMist": "Dati applicativi",
-                "swarmUpload": "Carica a Swarm"
+                "languages": "Lingue",
+                "default": "Default",
+                "langCodes": {
+                    "ca": "Català",
+                    "de": "Deutsch",
+                    "en": "English",
+                    "es": "Español",
+                    "fa": "فارسى",
+                    "fr": "Français",
+                    "it": "Italiano",
+                    "ja": "日本語",
+                    "ko": "한국어 ",
+                    "nl": "Nederlands",
+                    "nb": "Norsk",
+                    "pt": "Português",
+                    "sq": "Shqip",
+                    "ru": "Pусский",
+                    "zh": "普通話",
+                    "zh-TW": "國語"
+                }
             },
             "develop": {
                 "label": "Sviluppo",
@@ -43,12 +62,13 @@
                 "devToolsWebview": "__webview__",
                 "runTests": "Esegui Test",
                 "logFiles": "Mostra file di log",
+                "openRemix": "Apri IDE Remix",
                 "ethereumNode": "Nodo Ethereum",
                 "network": "Rete",
                 "mainNetwork": "Rete principale",
                 "startMining": "⛏ Inizia mining",
                 "stopMining": "⛏ Ferma mining",
-                "openRemix": "Apri IDE Remix"
+                "enableSwarm": "Abilita Swarm"
             },
             "window": {
                 "label": "Finestra",
@@ -58,15 +78,17 @@
             },
             "help": {
                 "label": "Aiuto",
+                "mistWiki": "Risoluzione dei problemi ed aiuto",
+                "gitter": "Canale Mist su Gitter",
                 "reportBug": "Riporta un problema su Github"
             }
         },
         "errors": {
             "nodeConnect": "Impossibile connettersi al nodo. Controlla i log per dettagli:",
-            "nodeStartup": "Il nodo non puó essere avviato, ne hai giá uno in esecuzione? Il database è in fase di aggiornamento in questo momento?",
+            "nodeStartup": "Il nodo non può essere avviato, ne hai già uno in esecuzione? Il database è in fase di aggiornamento in questo momento?",
             "timeSync": {
                 "title": "Il tuo orologio di sistema non è sincronizzato.",
-                "description": "E' necessario sincronizzare l'orologio di sistema con un time server per connettere correttamente il tuo nodo alla rete Ethereum.",
+                "description": "È necessario sincronizzare l'orologio di sistema con un time server per connettere correttamente il tuo nodo alla rete Ethereum.",
                 "win32": "Apri le impostazioni dell'orologio di sistema, seleziona Orario internet e metti un tick sul box. Segui questa guida (in inglese) per i dettagli: http://www.guidingtech.com/3119/windows-clock-sync/",
                 "linux": "Per abilitare la sincronia con un time server installa \"ntp\" via \"apt-get install ntp\".",
                 "darwin": "Per abilitare la sincronia dell'ora, apri le preferenze di orario e spunta \"Setta ora e data automaticamente\"."
@@ -78,6 +100,9 @@
             "legacyChain": {
                 "title": "Rilevata chain obsoleta",
                 "description": "Il tuo nodo si trova su una chain Ethereum Classic non supportata. Per usare questa chain usa strumenti forniti dal progetto ethereum classic da \nhttps://ethereumclassic.github.io.\n\nPer ritornare sulla chain principale di ethereum segui il tutorial seguente:\nhttps://github.com/ethereum/mist/releases/0.8.2"
+            },
+            "swarm": {
+                "notEnabled": "Swarm non è abilitato. Per abilitare Swarm devi cliccare su Abilita Swarm (menu -> Sviluppo -> Abilita Swarm)."
             }
         },
         "rightClick": {
@@ -90,14 +115,18 @@
             "blockReceivedShort": "Nuovo blocco",
             "blockNumber": "Il tuo ultimo numero di blocco",
             "timeSinceBlock": "Tempo trascorso dall'ultimo blocco",
-            "testnetExplain": "Sei connesso alla testnet, NON INVIARE alcun ether reale a questi indirizzi",
-            "peers": "nodi",
             "checkingWhichNetwork": "Controllo rete...",
-            "privateNetwork": "Private-net"
+            "privateNetwork": "Private-net",
+            "testnetExplain": "Sei connesso alla testnet, NON INVIARE alcun ether reale a questi indirizzi",
+            "peers": "nodi"
         },
         "sidebar": {
             "buttons": {
                 "browser": "Sfoglia"
+            },
+            "submenu": {
+                "account": "Account",
+                "connectAccounts": "Connetti account"
             }
         },
         "browserBar": {
@@ -110,9 +139,6 @@
             "runningNodeFound": "Trovato nodo Ethereum in esecuzione!",
             "nodeConnectionTimeout": "Impossibile avviare un nodo Ethereum!<br><small>Se <a href='https://www.ethereum.org/cli#geth' class='button' target='_blank'>hai installato Geth</a>, usa questo comando per eseguirlo:<br> <code>geth --ipcpath __path__</code></small><br> <small><a href='https://github.com/ethereum/mist/issues' class='button' target='_blank'> o riporta il problema </a></small>",
             "nodeBinaryNotFound": "Impossibile trovare l'eseguibile del nodo Ethereum !<br><small> <a href='https://www.ethereum.org/cli#geth' class='button' target='_blank'> Per favore avvialo manualmente prima. </a> </small>",
-            "nodeSyncing": "Il nodo Ethereum deve sincronizzarsi, attendere prego...",
-            "nodeSyncInfo": "Scaricamento blocco __displayBlock__ di __highestBlock__.",
-            "nodeSyncConnecting": "Alla ricerca di nodi...",
             "nodeStarting": "Nodo Ethereum in avvio...",
             "nodeStarted": "Nodo Ethereum avviato",
             "nodeConnected": "Nodo Ethereum connesso",
@@ -120,24 +146,40 @@
             "nodeStopped": "Nodo Ethereum arrestato",
             "nodeError": "Nodo Ethereum errore di connessione :'(",
             "unableToBindPort": "Nodo Ethereum non in esecuzione. Esiste altra istanza in esecuzione?",
-            "nodeSyncInfoStates": "Scaricamento blocco __displayBlock__ of __highestBlock__, <br> Scaricamento struttura chain __displayState__ of __displayKnownStates__",
-            "nodeSyncFoundPeers": "Connessione a __peers__ peers...",
+            "nodeSyncing": "Il nodo Ethereum deve sincronizzarsi, attendere prego...",
+            "nodeSyncInfo": "Scaricamento blocco __displayBlock__ di __highestBlock__.",
+            "nodeSyncConnecting": "Alla ricerca di nodi...",
+            "nodeSyncInfoStates": "Scaricamento blocco __displayBlock__ di __highestBlock__, <br> Scaricamento struttura chain __displayState__ di __displayKnownStates__",
+            "nodeSyncFoundPeers": "Connessione a __peers__ nodi ...",
             "launchApp": "Avvia Applicazione",
+            "retryConnection": "Riprova la connessione",
             "clientBinaries": {
                 "scanning": "Controlla aggiornamento nodo...",
                 "downloading": "Scaricamento nuovo nodo...",
-                "loadConfig": "Caricamento configurazione client...",
-                "filtering": "Filtro codice binario del client...",
-                "done": "Nodo Ethereum  aggiornato...",
+                "loadConfig": "Caricamento configurazione cliente...",
+                "filtering": "Filtro codice binario del cliente...",
+                "done": "Nodo Ethereum aggiornato...",
                 "error": "Errore durante lo scaricamento del codice binario."
             }
         },
         "popupWindows": {
+            "updateAvailable": {
+                "newVersionAvailable": "Nuova __name__ versione disponibile",
+                "version": "Versione",
+                "downloadURL": "Download URL",
+                "checksum": "Checksum",
+                "downloadAndRestart": "Aggiorna e riavvia",
+                "download": "Scarica nuova versione",
+                "skipUpdate": "Salta aggiornamento",
+                "checking": "Controlla aggiornamenti a __name__...",
+                "noUpdateFound": "Nessuna aggiornamento trovato. Stai eseguendo l'ultima versione di __name__."
+            },
             "requestAccount": {
                 "title": "Crea account",
                 "enterPassword": "Immetti password",
                 "repeatPassword": "Ripeti password",
                 "creating": "Generazione account...",
+                "backupHint": "Assicurati di fare i backup di tutti i file nella cartella \"keystore\". Indipendentemente da ciò, devi ANCHE assicurarti di non dimenticare le tue password o di averle salvate in modo sicuro in un password manager!\n\nI file wallet crittografati possono essere trovati nel menu -> File -> Backup -> Accounts. Conserva multiple copie della cartella \"keystore\" in diversi posti sicuri!",
                 "errors": {
                     "passwordMismatch": "Le due password non sono uguali.",
                     "passwordTooShort": "Usa una password più lunga"
@@ -156,33 +198,33 @@
                 "createContract": "Creazione contratto",
                 "estimatedFee": "Stima consumo (commissione)",
                 "estimatedGasError": "Dati non eseguibili, quindi verrà utilizzato tutto il gas fornito.",
-                "gasPrice": "Prezzo carburante (Gas)",
+                "transactionThrow": "Il contratto non consente l'esecuzione di questa transazione",
+                "overBlockGasLimit": "Il gas richiesto per questa esecuzione potrebbe eccedere il limite gas del blocco.",
+                "notEnoughGas": "Il gas potrebbe non essere sufficiente per completare con successo questa transazione.<br>Clicca qui per aumentare la quantità di gas.",
+                "noEstimate": "Impossibile stimare il gas necessario.",
+                "gasPrice": "Prezzo carburante (gas)",
                 "perMillionGas": "ether per milioni di gas",
                 "gasLimit": "Imposta limite di gas",
-                "data": "Dati",
+                "data": "Dati grezzi",
+                "parameters": "Parametri",
                 "buttons": {
                     "sendTransaction": "Invia transazione"
                 },
                 "errors": {
                     "connectionTimeout": "Impossibile connettersi al nodo, è forse terminato in modo inaspettato ?",
                     "wrongPassword": "Password errata",
-                    "multipleKeysMatchAddress": "Chiavi multiple per lo stesso indirizzo, per favore eliminare i duplicati dal keystore (menu -> accounts -> backup -> accounts)",
-                    "insufficientFundsForGas": "Credito insufficiente nel account pricipale (etherbase) per pagare il gas",
-                    "sameAccount": "Non può inviare a se stesso"
+                    "multipleKeysMatchAddress": "Chiavi multiple per lo stesso indirizzo, per favore eliminare i duplicati dal keystore (menu -> File -> Backup -> Accounts)",
+                    "insufficientFundsForGas": "Credito insufficiente nel account principale (etherbase) per pagare il gas",
+                    "sameAccount": "Non si può inviare a se stesso"
                 },
-                "transactionThrow": "Il contratto non consente l'esecuzione di questa transazione",
-                "noEstimate": "Impossibile stimare il gas necessario.",
-                "parameters": "Parametri",
                 "showRawBytecode": "mostra dati grezzi",
-                "showDecodedParameters": "mostra parameteri decodificati",
+                "showDecodedParameters": "mostra parametri decodificati",
                 "lookupData": "Provo a decodificare i dati",
-                "lookupDataExplainer": "Cerca questo su internet",
-                "overBlockGasLimit": "Il gas richiesto per questa esecuzione potrebbe eccedere il gas limit del blocco.",
-                "notEnoughGas": "Il Gas potrebbe non essere sufficiente per completare con successo questa transazione.<br>Clicca qui per aumentare la quantità di gas."
+                "lookupDataExplainer": "Cerca questo su internet"
             },
             "importAccount": {
                 "doYouHaveAWalletFile": "Hai un file per il wallet ?",
-                "walletFileDescription": "<p>Se hai partecipato alla pre-vendita Ethereum nel 2014, dovresti avere un file nominato<code>ethereum_wallet_backup.json</code>. E' stato scaricato dopo la vendita e inoltre inviato al tuo indirizzo e-mail</p>",
+                "walletFileDescription": "<p>Se hai partecipato alla pre-vendita Ethereum nel 2014, dovresti avere un file nominato<code>ethereum_wallet_backup.json</code>. È stato scaricato dopo la vendita e inoltre inviato al tuo indirizzo e-mail</p>",
                 "dropFilesHere": "Trascina file pre-vendita",
                 "importing": "Importazione...",
                 "buttons": {
@@ -194,23 +236,11 @@
                     "importFailed": "Impossibile importare il file: __error__"
                 }
             },
-            "updateAvailable": {
-                "newVersionAvailable": "Nuova __name__ versione disponibile",
-                "version": "Versione",
-                "downloadURL": "Download URL",
-                "checksum": "Checksum",
-                "downloadAndRestart": "Aggiorna e Riavvia",
-                "download": "Scarica nuova versione",
-                "skipUpdate": "Salta Aggiornamento",
-                "checking": "Controlla aggiornamenti a __name__...",
-                "noUpdateFound": "Nessuna aggiornamento trovato. Stai eseguendo l'ultima versione di __name__."
-
-            },
             "connectAccount": {
                 "chooseAccountTitle": "Scegli account",
                 "createAccount": "Crea nuovo account",
                 "pinToSidebar": "Aggancia applicazione alla barra laterale",
-                "connectAccountDescription": "Sta per condividere la tua identità con __dappName__. Questo consente all'applicazione di vedere ogni informazione pubblica del tuo account, compreso il relativo balance associato."
+                "connectAccountDescription": "Stai per condividere la tua identità con __dappName__. Questo consente all'applicazione di vedere ogni informazione pubblica del tuo account, compreso il relativo saldo associato."
             }
         }
     },


### PR DESCRIPTION
This updates the italian version of the translation files as mentioned within this comment: https://github.com/ethereum/mist/pull/3804#issuecomment-379712769

I basically updated all json key/value pairs based on the english translation file mist.en.i18n.json:  https://github.com/ethereum/mist/blob/125fa014e539b6bdd8e7555f8fd3f3a1e0fe9a10/interface/i18n/mist.en.i18n.json

I added some missing strings like mistWiki, gitter, swam.notEnabled, retryConnection, backupHint etc

I kindly invite @hacktar to review it. Most of all, the newly added translation strings should probably be double-checked by an additional native speaker (@hacktar you?)