### PR TITLE
i18n: update translations for multipleKeysMatchAddress, Accounts menu -> File menu

### DIFF
--- a/interface/i18n/mist.ca.i18n.json
+++ b/interface/i18n/mist.ca.i18n.json
@@ -208,7 +208,7 @@
                 "errors": {
                     "connectionTimeout": "No s'ha pogut connectar al node, ha fallat la tasca al fons?",
                     "wrongPassword": "Contrasenya errònia",
-                    "multipleKeysMatchAddress": "Multiples claus coincideixen amb l'adreça. Si us plau eliminar els duplicats del fitxer de claus (menú -> comptes -> copia de seguretat -> comptes)",
+                    "multipleKeysMatchAddress": "Multiples claus coincideixen amb l'adreça. Si us plau eliminar els duplicats del fitxer de claus (menú -> Fitxer -> Copia de seguretat -> Comptes)",
                     "insufficientFundsForGas": "Saldo insuficient al compte principal (etherbase) per pagar el gas",
                     "sameAccount": "No es pot enviar a un mateix"
                 },

--- a/interface/i18n/mist.de.i18n.json
+++ b/interface/i18n/mist.de.i18n.json
@@ -138,7 +138,7 @@
                 "enterPassword": "Passwort eingeben",
                 "repeatPassword": "Passwort wiederholen",
                 "creating": "Konto wird angelegt...",
-                "backupHint": "Bitte stelle sicher dass du von allen Schlüsseldateien Sicherungen erstellst. Unabhängig davon solltest du dich AUCH vergewissern dass du deine Passwörter nicht vergisst bzw. dass du diese sicher in einem Passwort-Manager abgespeichert hast!\n\nDie verschlüsselten Wallet-Dateien findest du im Hauptmenü -> Datei -> Sicherung -> Konten. Bewahre Kopien des \"keystore\"  Ordners an einem sicheren Ort auf!",
+                "backupHint": "Bitte stelle sicher dass du von allen Schlüsseldateien Sicherungen erstellst. Unabhängig davon solltest du dich AUCH vergewissern dass du deine Passwörter nicht vergisst bzw. dass du diese sicher in einem Passwort-Manager abgespeichert hast!\n\nDie verschlüsselten Wallet-Dateien findest du im Hauptmenü -> Datei -> Sicherung -> Konten. Bewahre Kopien des \"keystore\" Ordners an einem sicheren Ort auf!",
                 "errors": {
                     "passwordMismatch": "Die Passwörter stimmen nicht überein.",
                     "passwordTooShort": "Wähle ein längeres Passwort..."
@@ -166,7 +166,7 @@
                 "errors": {
                     "connectionTimeout": "Eine Verbindung mit dem Softwareknoten war nicht möglich, eventuell ist der Softwareknoten im Hintergrund abgestürzt?",
                     "wrongPassword": "Falsches Passwort",
-                    "multipleKeysMatchAddress": "Mehrere Konten stimmen mit der Adresse überein, bitte entferne Duplikate aus dem keystore Verzeichnis (Menü -> Konten -> Sicherung -> Konten)",
+                    "multipleKeysMatchAddress": "Mehrere Konten stimmen mit der Adresse überein, bitte entferne Duplikate aus dem keystore Verzeichnis (Menü -> Datei -> Sicherung -> Konten)",
                     "insufficientFundsForGas": "Zu wenig Mittel im Hauptkonto (etherbase) um für Gas zu bezahlen",
                     "sameAccount": "Kann nicht zum gleichen Konto schicken."
                 },

--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -213,7 +213,7 @@
                 "errors": {
                     "connectionTimeout": "Couldn't connect to the node, did it crash in the background?",
                     "wrongPassword": "Wrong password",
-                    "multipleKeysMatchAddress": "Multiple keys match address.  Please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Multiple keys match address. Please remove duplicates from keystore (menu -> File -> Backup -> Accounts)",
                     "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas",
                     "sameAccount": "Can't send to itself"
                 },

--- a/interface/i18n/mist.es.i18n.json
+++ b/interface/i18n/mist.es.i18n.json
@@ -166,7 +166,7 @@
                 "errors": {
                     "connectionTimeout": "No se pudo conectar al nodo, ha dejado de funcionar en segundo plano?",
                     "wrongPassword": "Contraseña incorrecta",
-                    "multipleKeysMatchAddress": "Multiple keys match address, please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Multiple keys match address. Please remove duplicates from keystore (menu -> File -> Backup -> Accounts)",
                     "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas",
                     "sameAccount": "Can't send to itself"
                 },

--- a/interface/i18n/mist.fa.i18n.json
+++ b/interface/i18n/mist.fa.i18n.json
@@ -180,7 +180,7 @@
                 "errors": {
                     "connectionTimeout": "Couldn't connect to the node, did it crash in the background?",
                     "wrongPassword": "Wrong password",
-                    "multipleKeysMatchAddress": "Multiple keys match address, please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Multiple keys match address. Please remove duplicates from keystore (menu -> File -> Backup -> Accounts)",
                     "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas",
                     "sameAccount": "Can't send to itself"
                 },

--- a/interface/i18n/mist.fr.i18n.json
+++ b/interface/i18n/mist.fr.i18n.json
@@ -166,7 +166,7 @@
                 "errors": {
                     "connectionTimeout": "La connexion au nœud n'a pas pu s'établir, est-ce un plantage dans l'arrière-plan ?",
                     "wrongPassword": "Mauvais mot de passe",
-                    "multipleKeysMatchAddress": "Multiple keys match address, please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Multiple keys match address. Please remove duplicates from keystore (menu -> File -> Backup -> Accounts)",
                     "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas",
                     "sameAccount": "Can't send to itself"
                 },

--- a/interface/i18n/mist.ja.i18n.json
+++ b/interface/i18n/mist.ja.i18n.json
@@ -166,7 +166,7 @@
                 "errors": {
                     "connectionTimeout": "ノードにつなげませんでした、バックグラウンドで落ちていますか?",
                     "wrongPassword": "パスワードが間違っています",
-                    "multipleKeysMatchAddress": "複数のキーが一致する場合は、キーストアから重複を削除してください (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "複数のキーが一致する場合は、キーストアから重複を削除してください (アカウント -> バックアップを取る -> アカウント)",
                     "insufficientFundsForGas": "GAS を支払うためにメインアカウント(etherbase)に不十分な資金",
                     "sameAccount": "同一アカウントには送信できません"
                 },

--- a/interface/i18n/mist.nb.i18n.json
+++ b/interface/i18n/mist.nb.i18n.json
@@ -166,7 +166,7 @@
                 "errors": {
                     "connectionTimeout": "Kunne ikke koble til noden, krasjet den i bakgrunnen?",
                     "wrongPassword": "Feil passord",
-                    "multipleKeysMatchAddress": "Multiple keys match address, please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Multiple keys match address. Please remove duplicates from keystore (menu -> File -> Backup -> Accounts)",
                     "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas",
                     "sameAccount": "Can't send to itself"
                 },

--- a/interface/i18n/mist.nl.i18n.json
+++ b/interface/i18n/mist.nl.i18n.json
@@ -45,7 +45,7 @@
                 }
             },
             "file": {
-                "label": "Accounts",
+                "label": "Bestand",
                 "importPresale": "Importeer Accounts",
                 "newAccount": "Nieuw account",
                 "backup": "Backup",
@@ -198,7 +198,7 @@
                 "errors": {
                     "connectionTimeout": "Kon niet verbinden met de node, is het in de achtergrond uitgevallen?",
                     "wrongPassword": "Onjuist wachtwoord",
-                    "multipleKeysMatchAddress": "Meerdere keys matchen hebben hetzelfde adres, verwijder duplicaten uit de keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Meerdere keys matchen hebben hetzelfde adres, verwijder duplicaten uit de keystore (menu -> Bestand -> Backup -> Accounts)",
                     "insufficientFundsForGas": "Onvoldoende saldo in hoofd account (Etherbase) om gas te betalen",
                     "sameAccount": "Kan niet naar zichzelf versturen"
                 },

--- a/interface/i18n/mist.pt.i18n.json
+++ b/interface/i18n/mist.pt.i18n.json
@@ -166,7 +166,7 @@
                 "errors": {
                     "connectionTimeout": "Não pode se conectar com Node, é possível que tenha sido interrompido pelo sistema",
                     "wrongPassword": "Senha errada",
-                    "multipleKeysMatchAddress": "Multiple keys match address, please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Multiple keys match address. Please remove duplicates from keystore (Arquivos -> Cópia de segurança -> Contas)",
                     "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas",
                     "sameAccount": "Can't send to itself"
                 },

--- a/interface/i18n/mist.sq.i18n.json
+++ b/interface/i18n/mist.sq.i18n.json
@@ -189,7 +189,7 @@
                 "errors": {
                     "connectionTimeout": "Nuk mund të lidhet me nyjen. Mos ka probleme diku?",
                     "wrongPassword": "Fjalëkalim i gabuar",
-                    "multipleKeysMatchAddress": "Disa  çelësa i përshtaten kësaj adrese; ju lutemi hiqni kopjet e dyfishta nga mbajtësja e çelësave (Menu -> Llogaritë -> Ruaj kopje tjetër -> Llogari)",
+                    "multipleKeysMatchAddress": "Disa  çelësa i përshtaten kësaj adrese; ju lutemi hiqni kopjet e dyfishta nga mbajtësja e çelësave (menunë -> Skedari -> Ruaj kopje rezervë -> Llogari)",
                     "insufficientFundsForGas": "Fonde të pamjaftueshme në adresën kryesore (etherbase) për të paguar për karburant",
                     "sameAccount": "Nuk mund t'i dërgohet vetes"
                 },

--- a/interface/i18n/mist.zh-TW.i18n.json
+++ b/interface/i18n/mist.zh-TW.i18n.json
@@ -166,7 +166,7 @@
                 "errors": {
                     "connectionTimeout": "無法連接該節點，後台節點是否崩潰了？",
                     "wrongPassword": "密碼錯誤",
-                    "multipleKeysMatchAddress": "Multiple keys match address, please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Multiple keys match address. Please remove duplicates from keystore (menu -> File -> Backup -> Accounts)",
                     "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas",
                     "sameAccount": "Can't send to itself"
                 },

--- a/interface/i18n/mist.zh.i18n.json
+++ b/interface/i18n/mist.zh.i18n.json
@@ -166,7 +166,7 @@
                 "errors": {
                     "connectionTimeout": "无法连接该节点，后台节点是否可能崩溃了？",
                     "wrongPassword": "密码错误",
-                    "multipleKeysMatchAddress": "Multiple keys match address, please remove duplicates from keystore (menu -> accounts -> backup -> accounts)",
+                    "multipleKeysMatchAddress": "Multiple keys match address. Please remove duplicates from keystore (menu -> File -> Backup -> Accounts)",
                     "insufficientFundsForGas": "Insufficient funds in main account (etherbase) to pay for gas",
                     "sameAccount": "Can't send to itself"
                 },


### PR DESCRIPTION
The translations of the "multipleKeysMatchAddress" values were not up to date. Several translations still referenced a "Accounts" menu while there is no such menu available.
The "Accounts" menu was renamed into the "File" menu a while ago.