### PR TITLE
Optimize update checker

### DIFF
--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -29,15 +29,14 @@ const check = (exports.check = () => {
   })
     .then(res => {
       const release = res.body;
-      log.debug(release);
+
       if (!release) {
         log.debug('No releases available to check against.');
 
         return;
       }
 
-      if (semver.gt(release.tag_name, 'v0.9.0')) {
-      //if (semver.gt(release.tag_name, Settings.appVersion)) {
+      if (semver.gt(release.tag_name, Settings.appVersion)) {
         log.info(
           `App (${Settings.appVersion}) is out of date. New ${
             release.tag_name

--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -24,7 +24,7 @@ const check = (exports.check = () => {
   }
 
   return got('https://api.github.com/repos/ethereum/mist/releases/latest', {
-    timeout: 5000,
+    timeout: 30000,
     json: true
   })
     .then(res => {

--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -23,39 +23,31 @@ const check = (exports.check = () => {
       break;
   }
 
-  return got('https://api.github.com/repos/ethereum/mist/releases', {
-    timeout: 3000,
+  return got('https://api.github.com/repos/ethereum/mist/releases/latest', {
+    timeout: 5000,
     json: true
   })
     .then(res => {
-      const releases = _.filter(res.body, release => {
-        return (
-          !_.get(release, 'draft') &&
-          _.get(release, 'name', '')
-            .toLowerCase()
-            .indexOf(str) >= 0
-        );
-      });
-
-      if (!releases.length) {
+      const release = res.body;
+      log.debug(release);
+      if (!release) {
         log.debug('No releases available to check against.');
 
         return;
       }
 
-      const latest = releases[0];
-
-      if (semver.gt(latest.tag_name, Settings.appVersion)) {
+      if (semver.gt(release.tag_name, 'v0.9.0')) {
+      //if (semver.gt(release.tag_name, Settings.appVersion)) {
         log.info(
           `App (${Settings.appVersion}) is out of date. New ${
-            latest.tag_name
+            release.tag_name
           } found.`
         );
 
         return {
-          name: latest.name,
-          version: latest.tag_name,
-          url: latest.html_url
+          name: release.name,
+          version: release.tag_name,
+          url: release.html_url
         };
       }
 


### PR DESCRIPTION
#### What does it do?

Currently, we've been experiencing some request timeouts on our update checker. The previous endpoint's median response time was frequently above the request timeout made by Mist (3000ms).

```
Percentage of the requests served within a certain time (ms)
  50%   3028
  66%   3148
  75%   3285
  80%   4040
  90%   4304
  95%   4304
  98%   4304
  99%   4304
 100%   4304 (longest request)
```

This code makes requests to the single latest version, resulting in a 94% data transfer (from 500kb to 29kb). From preliminary benchmarks, even the longest request is within the 3000ms timeout. 

```
Percentage of the requests served within a certain time (ms)
  50%    636
  66%    660
  75%    711
  80%    715
  90%   1095
  95%   1095
  98%   1095
  99%   1095
 100%   1095 (longest request)
```

This PR increases the current timeout to 5000ms.

#### Any helpful background information?

In the past, all Mist/ethereum wallet versions were flagged as Pre-releases. Github doesn't have an API endpoint for the "latest pre-release", though. The only way to know if there were new versions was to query `/mist/releases/`, which would return all published versions, ever.

Today I've changed the latest versions to a 'release' state, so we can make use of that lighter API endpoint.
