### PR TITLE
When gas estimate fails, defaults to 1M gas but allow tx

### DIFF
--- a/interface/client/templates/popupWindows/sendTransactionConfirmation.html
+++ b/interface/client/templates/popupWindows/sendTransactionConfirmation.html
@@ -56,11 +56,11 @@
 
                 {{#if transactionInvalid}}
                     {{#if (TemplateVar.get "gasLoading") }}
-                        <p class="info gas-loading"> 
+                        <p class="info gas-loading">
                             {{> spinner}}
                         </p>
                     {{ else }}
-                        <p class="info dapp-error"> 
+                        <p class="info dapp-error">
                             {{i18n "mist.popupWindows.sendTransactionConfirmation.estimatedGasError"}}
                         </p>
                     {{/if}}
@@ -71,18 +71,24 @@
                                 {{i18n "mist.popupWindows.sendTransactionConfirmation.overBlockGasLimit"}}
                             </div>
                         {{else}}
-                            {{#if $and data (TemplateVar.get "toIsContract")}}
-                                <p class="info">
-                                {{i18n "mist.popupWindows.sendTransactionConfirmation.contractExecutionInfo"}}
-                                </p>
-                            {{/if}}
 
-                            {{#unless to}}
-                                <p class="info">
-                                {{i18n "mist.popupWindows.sendTransactionConfirmation.contractCreationInfo"}}
-                                </p>
-                            {{/unless}}
+                          {{#if $eq (TemplateVar.get "gasError") "defaultGas"}}
+                              <div class="info dapp-error">
+                                  {{i18n "mist.popupWindows.sendTransactionConfirmation.defaultGas"}}
+                              </div>
+                          {{else}}
+                              {{#if $and data (TemplateVar.get "toIsContract")}}
+                                  <p class="info">
+                                  {{i18n "mist.popupWindows.sendTransactionConfirmation.contractExecutionInfo"}}
+                                  </p>
+                              {{/if}}
 
+                              {{#unless to}}
+                                  <p class="info">
+                                  {{i18n "mist.popupWindows.sendTransactionConfirmation.contractCreationInfo"}}
+                                  </p>
+                              {{/unless}}
+                          {{/if}}
                         {{/if}}
                     {{else}}
                         <div class="info dapp-error not-enough-gas" style="cursor: pointer;">

--- a/interface/client/templates/popupWindows/sendTransactionConfirmation.js
+++ b/interface/client/templates/popupWindows/sendTransactionConfirmation.js
@@ -14,7 +14,7 @@ var setWindowSize = function(template) {
   });
 };
 
-var defaultEstimateGas = 50000000;
+var defaultEstimateGas = 1000000;
 
 /**
 The sendTransaction confirmation popup window template
@@ -117,6 +117,8 @@ Template['popupWindows_sendTransactionConfirmation'].onCreated(function() {
       TemplateVar.set('gasError', 'notEnoughGas');
     } else if (TemplateVar.get('estimatedGas') > 4000000) {
       TemplateVar.set('gasError', 'overBlockGasLimit');
+    } else if (TemplateVar.get('estimatedGas') == defaultEstimateGas) {
+      TemplateVar.set('gasError', 'defaultGas');
     } else {
       TemplateVar.set('gasError', null);
     }
@@ -227,6 +229,9 @@ Template['popupWindows_sendTransactionConfirmation'].onCreated(function() {
               );
             }
           });
+        } else {
+          TemplateVar.set(template, 'estimatedGas', defaultEstimateGas);
+          TemplateVar.set(template, 'providedGas', defaultEstimateGas);
         }
         TemplateVar.set(template, 'gasLoading', false);
       });
@@ -236,6 +241,8 @@ Template['popupWindows_sendTransactionConfirmation'].onCreated(function() {
       // so the user can see an error message
       setTimeout(() => {
         TemplateVar.set(template, 'gasLoading', false);
+        TemplateVar.set(template, 'estimatedGas', defaultEstimateGas);
+        TemplateVar.set(template, 'providedGas', defaultEstimateGas);
       }, 25000);
     }
   });

--- a/interface/i18n/mist.en.i18n.json
+++ b/interface/i18n/mist.en.i18n.json
@@ -239,6 +239,8 @@
           "The gas required for this execution could exceed the block gas limit.",
         "notEnoughGas":
           "Gas might not be enough to successfully finish this transaction.<br>Click here to increase the gas amount.",
+        "defaultGas":
+          "Couldn't estimate gas, resorting to default parameters. Transaction is likely cheaper than the estimate",
         "noEstimate": "We couldn't estimate the gas.",
         "gasPrice": "Gas price",
         "perMillionGas": "ether per million gas",

--- a/modules/ipc/methods/base.js
+++ b/modules/ipc/methods/base.js
@@ -1,9 +1,9 @@
 const _ = require('../../utils/underscore.js');
 const Q = require('bluebird');
-
 const log = require('../../utils/logger').create('method');
 const Windows = require('../../windows');
 const db = require('../../db');
+
 import ethereumNodeRemote from '../../ethereumNodeRemote';
 
 /**
@@ -24,8 +24,7 @@ module.exports = class BaseProcessor {
       'personal_newAccount',
       'personal_signTransaction',
       'eth_subscribe',
-      'eth_unsubscribe',
-      'eth_estimateGas'
+      'eth_unsubscribe'
     ];
   }
 


### PR DESCRIPTION
When the gas estimation fails for some reason, the app treats transactions as if they could not be sent, blocking any activity. This PR instead allows them, but defaults gas amount to 1M gas