### PR TITLE
Fixes disabled menu buttons

### DIFF
--- a/modules/menuItems.js
+++ b/modules/menuItems.js
@@ -599,10 +599,7 @@ let menuTempl = function(webviews) {
     submenu: [
       {
         label: i18n.t('mist.applicationMenu.develop.syncModeLight'),
-        enabled:
-          ethereumNode.isOwnNode &&
-          ethereumNode.isGeth &&
-          !ethereumNode.isDevNetwork,
+        enabled: ethereumNode.isOwnNode && !ethereumNode.isDevNetwork,
         checked: store.getState().nodes.local.syncMode === 'light',
         type: 'checkbox',
         click() {
@@ -629,10 +626,7 @@ let menuTempl = function(webviews) {
       },
       {
         label: i18n.t('mist.applicationMenu.develop.syncModeNoSync'),
-        enabled:
-          ethereumNode.isOwnNode &&
-          ethereumNode.isGeth &&
-          !ethereumNode.isDevNetwork,
+        enabled: ethereumNode.isOwnNode && !ethereumNode.isDevNetwork,
         checked: store.getState().nodes.local.syncMode === 'nosync',
         type: 'checkbox',
         click() {


### PR DESCRIPTION
#### What does it do?
Uses Redux state to determine client is geth. 
#### Any helpful background information?
ethereumNode's `_type` isn't updated before the menu button state is determined, so the buttons appear disabled. Ideally all state is derived from Redux anyway.