### PR TITLE
Gas estimation fixes

### DIFF
--- a/interface/client/templates/popupWindows/sendTransactionConfirmation.js
+++ b/interface/client/templates/popupWindows/sendTransactionConfirmation.js
@@ -115,7 +115,7 @@ Template['popupWindows_sendTransactionConfirmation'].onCreated(function() {
       TemplateVar.get('estimatedGas') > Number(TemplateVar.get('providedGas'))
     ) {
       TemplateVar.set('gasError', 'notEnoughGas');
-    } else if (TemplateVar.get('estimatedGas') > 4000000) {
+    } else if (TemplateVar.get('estimatedGas') > 8000000) {
       TemplateVar.set('gasError', 'overBlockGasLimit');
     } else if (TemplateVar.get('estimatedGas') == defaultEstimateGas) {
       TemplateVar.set('gasError', 'defaultGas');


### PR DESCRIPTION
#### What does it do?
- Fixes gas estimation callback into promise
- Handles timeout errors better
- If gasEstimation fails, defaults to the maximum of `Math.max(provided-by-dapp, defaultGasPrice)`
- Tweaked blockGasLimit magic number (needs to be refactored out of it)
- Greater default gasLimit, in case of gasEstimation errors

#### Any helpful background information?

#### Relevant screenshots?

![screen shot 2018-06-20 at 7 51 45 pm](https://user-images.githubusercontent.com/47108/41688718-9aa16c3a-74c3-11e8-878b-c9b8aa083ad5.png)