### PR TITLE
Error in other languages

### DIFF
--- a/modules/ipcCommunicator.js
+++ b/modules/ipcCommunicator.js
@@ -59,7 +59,7 @@ ipc.on('backendAction_setWindowSize', (e, width, height) => {
   const senderWindow = Windows.getById(windowId);
 
   if (senderWindow) {
-    senderWindow.window.setSize(width, height);
+    senderWindow.window.setSize(width, height|0);
     senderWindow.window.center(); // ?
   }
 });


### PR DESCRIPTION
When the text of the screen is displayed in Korean, an error occurred because the screen size is displayed as a decimal point.

#### What does it do?
Converts a decimal number to an integer

#### Any helpful background information?
When displayed on the screen in Korean

#### Which code should the reviewer start with?

#### New dependencies? What are they used for?
not

#### Relevant screenshots?

error code:
?[31m[2018-07-26T18:40:30.853] [ERROR] main - ?[39mUNCAUGHT EXCEPTION TypeError: Error processing argument at index 1, conversion failure from 542.3910000000001
    at EventEmitter.ipc.on (E:/project/git/mist/modules/ipcCommunicator.js:65:25)
    at emitThree (events.js:135:13)
    at EventEmitter.emit (events.js:216:7)
    at WebContents.<anonymous> (E:\project\git\mist\node_modules\electron\dist\resources\electron.asar\browser\api\web-contents.js:266:13)
    at emitTwo (events.js:125:13)
    at WebContents.emit (events.js:213:7)