### PR TITLE
the send pop-up does not open issue.

### DIFF
--- a/modules/ipcCommunicator.js
+++ b/modules/ipcCommunicator.js
@@ -59,7 +59,7 @@ ipc.on('backendAction_setWindowSize', (e, width, height) => {
   const senderWindow = Windows.getById(windowId);
 
   if (senderWindow) {
-    senderWindow.window.setSize(width, height);
+    senderWindow.window.setSize(width, height | 0);
     senderWindow.window.center(); // ?
   }
 });


### PR DESCRIPTION
### Issue 
When trying to transmit Mist Ethereum Wallet version of Korean,
Because of the font size, the size of the Send popup is different, so the height is not a decimal number.
So an error occurred in senderWindow.window.setSize (width, height), and the send pop-up does not open.

### solution
Converts the send pop-up height to integer.
=> senderWindow.window.setSize (width, height | 0)
