### PR TITLE
Use Buffer.from instead of new Buffer

### DIFF
--- a/customProtocols.js
+++ b/customProtocols.js
@@ -3,7 +3,7 @@ const { protocol } = require('electron');
 protocol.registerHttpProtocol(
   'mist',
   (request, callback) => {
-    // callback({mimeType: 'text/html', data: new Buffer('<h5>Response</h5>')});
+    // callback({mimeType: 'text/html', data: Buffer.from('<h5>Response</h5>')});
 
     console.log(
       request.url.indexOf('mist://interface') !== -1

--- a/gulpTasks/maintenance.js
+++ b/gulpTasks/maintenance.js
@@ -88,7 +88,7 @@ gulp.task('update-nodes', cb => {
                           geth.platforms[platform][arch].download.url.split('/')
                         )
                       ) {
-                        const sum = new Buffer(
+                        const sum = Buffer.from(
                           blob.Properties[0]['Content-MD5'][0],
                           'base64'
                         );

--- a/modules/abi.js
+++ b/modules/abi.js
@@ -24,7 +24,7 @@ ipc.on('backendAction_decodeFunctionSignature', (event, _signature, _data) => {
   const paramTypes = signature[1].split(',');
 
   try {
-    const paramsResponse = abi.rawDecode(paramTypes, new Buffer(data, 'hex'));
+    const paramsResponse = abi.rawDecode(paramTypes, Buffer.from(data, 'hex'));
     const paramsDictArr = [];
 
     // Turns addresses into proper hex string


### PR DESCRIPTION
#### What does it do?
This PR replaces all new Buffer with Buffer.from. We should not use Buffer constructor which is deprecated and unsafe.

#### Which code should the reviewer start with?
modules/abi.js

#### Any helpful background information?
The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe

#### New dependencies? What are they used for?
None

#### Relevant screenshots?
None