### PR TITLE
Using local yarn instance instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Now you're ready to initialize Mist for development:
 ```bash
 $ git clone https://github.com/ethereum/mist.git
 $ cd mist
+$ git submodule update --init --recursive
 $ yarn
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,6 @@ install:
   # installs global dependencies
   - choco install meteor 
   - choco install nsis
-  # prevents node 10 to be installed, as it's a dependency of yarn
-  - choco install yarn --ignore-dependencies
 
   - refreshenv
   - ps: refreshenv

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "precommit": "pretty-quick --staged",
-    "postinstall": "git submodule update --recursive && yarn task pack-wallet && (cd interface && yarn)",
+    "postinstall": "git submodule update --init --recursive && yarn task pack-wallet && (cd interface && yarn)",
     "dev:electron": "electron -r babel-register main.js",
     "dev:meteor": "cd interface && meteor --no-release-check",
     "dev:tools": "remotedev & (sleep 3 && open http://localhost:8000)",


### PR DESCRIPTION
#### What does it do?
On sep 4th, Appveyor tests started to fail during `yarn` installation. This PR aims to fix that. Yarn is now available in their VM: https://www.appveyor.com/docs/build-environment/#tools

As a bonus, a project setup improvement re: git submodules in package.json. 

#### Any helpful background information?
We use `chocolatey` package manager in windows for some global dependencies. 

#### Which code should the reviewer start with?
--

#### New dependencies? What are they used for?
-- 

#### Relevant screenshots?
-- 