### PR TITLE
Fixes NodeInfo color bugs

### DIFF
--- a/interface/client/appStart.js
+++ b/interface/client/appStart.js
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { getLanguage } from './actions.js';
 import About from '../components/About';
 import RequestAccount from '../components/RequestAccount';
-import NodeInfo from '../components/NodeInfo';
+import NodeInfo from '../components/NodeInfo/';
 import SendTx from '../components/SendTx/';
 import TxHistory from '../components/TxHistory/';
 

--- a/interface/client/styles/nodeInfo.import.less
+++ b/interface/client/styles/nodeInfo.import.less
@@ -212,3 +212,23 @@ progress[value]::-webkit-progress-bar {
     box-shadow: 0 0 0 0 rgba(36, 195, 58, 0);
   }
 }
+
+.pulse-light__blue {
+  animation: beaconBlue ease-in-out;
+  animation-duration: 2s;
+}
+
+@keyframes beaconBlue {
+  0% {
+    -moz-box-shadow: 0 0 0 0 rgba(0, 170, 250, 0.4);
+    box-shadow: 0 0 0 0 rgba(0, 170, 250, 0.4);
+  }
+  70% {
+    -moz-box-shadow: 0 0 0 10px rgba(0, 170, 250, 0);
+    box-shadow: 0 0 0 10px rgba(0, 170, 250, 0);
+  }
+  100% {
+    -moz-box-shadow: 0 0 0 0 rgba(0, 170, 250, 0);
+    box-shadow: 0 0 0 0 rgba(0, 170, 250, 0);
+  }
+}

--- a/interface/components/NodeInfo/StatusLight.js
+++ b/interface/components/NodeInfo/StatusLight.js
@@ -1,0 +1,91 @@
+import React, { Component } from 'react';
+import moment from 'moment';
+import PieChart from 'react-minimal-pie-chart';
+
+class StatusLight extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      pulseColorClass: ''
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    // if new block arrived, add animation to light
+    if (this.isNewBlock(prevProps, this.props)) {
+      const pulseColorClass =
+        prevProps.active === 'remote'
+          ? 'pulse-light__orange'
+          : this.props.network === 'main'
+            ? 'pulse-light__green'
+            : 'pulse-light__blue';
+
+      this.setState({ pulseColorClass }, () => {
+        setTimeout(() => {
+          this.setState({ pulseColorClass: '' });
+        }, 2000);
+      });
+    }
+  }
+
+  isNewBlock(prevProps, newProps) {
+    if (prevProps.active === 'remote') {
+      return prevProps.remote.blockNumber !== newProps.remote.blockNumber;
+    } else {
+      return prevProps.local.blockNumber !== newProps.local.blockNumber;
+    }
+  }
+
+  secondsSinceLastBlock() {
+    const { active } = this.props;
+    const lastBlock = moment(this.props[active].timestamp, 'X');
+    return moment().diff(lastBlock, 'seconds');
+  }
+
+  render() {
+    const { active, network, local, remote } = this.props;
+
+    let dotColor = network == 'main' ? '#7ed321' : '#00aafa';
+
+    const { highestBlock, currentBlock, startingBlock } = local.sync;
+    const progress =
+      ((currentBlock - startingBlock) / (highestBlock - startingBlock)) * 100;
+
+    return (
+      <div className="pie-container">
+        <div
+          id="node-info__light"
+          className={this.state.pulseColorClass}
+          style={{
+            backgroundColor:
+              this.secondsSinceLastBlock() > 60
+                ? 'red'
+                : active === 'remote'
+                  ? 'orange'
+                  : dotColor
+          }}
+        />
+        {active === 'remote' &&
+          currentBlock !== 0 && (
+            <PieChart
+              startAngle={-90}
+              style={{
+                position: 'absolute',
+                top: 22,
+                left: 0,
+                zIndex: 2,
+                height: 16
+              }}
+              data={[
+                { value: progress || 0, key: 1, color: dotColor },
+                { value: 100 - (progress || 1), key: 2, color: 'orange' }
+              ]}
+            />
+          )}
+      </div>
+    );
+  }
+}
+
+export default StatusLight;

--- a/interface/components/NodeInfo/index.js
+++ b/interface/components/NodeInfo/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
-import PieChart from 'react-minimal-pie-chart';
-import { setLocalPeerCount } from '../actions.js';
+import StatusLight from './StatusLight';
+import { setLocalPeerCount } from '../../actions.js';
 
 class NodeInfo extends Component {
   constructor(props) {
@@ -10,8 +10,7 @@ class NodeInfo extends Component {
 
     this.state = {
       showSubmenu: false,
-      ticks: 0,
-      lightClasses: ''
+      ticks: 0
     };
   }
 
@@ -20,29 +19,6 @@ class NodeInfo extends Component {
     this.interval = setInterval(() => {
       this.tick();
     }, 1000);
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    // if new block arrived, add animation to light
-    if (this.isNewBlock(prevProps, this.props)) {
-      const lightClasses =
-        prevProps.active === 'remote'
-          ? 'pulse-light__orange'
-          : 'pulse-light__green';
-      this.setState({ lightClasses }, () => {
-        setTimeout(() => {
-          this.setState({ lightClasses: '' });
-        }, 2000);
-      });
-    }
-  }
-
-  isNewBlock(prevProps, newProps) {
-    if (prevProps.active === 'remote') {
-      return prevProps.remote.blockNumber !== newProps.remote.blockNumber;
-    } else {
-      return prevProps.local.blockNumber !== newProps.local.blockNumber;
-    }
   }
 
   componentWillUnmount() {
@@ -253,51 +229,8 @@ class NodeInfo extends Component {
     );
   }
 
-  renderStatusLight() {
-    const { active, network, remote } = this.props;
-
-    const timeSince = moment(remote.timestamp, 'X');
-    const diff = moment().diff(timeSince, 'seconds');
-
-    let dotColor = network == 'main' ? '#7ed321' : '#00aafa';
-
-    const { highestBlock, currentBlock, startingBlock } = this.props.local.sync;
-    const progress =
-      ((currentBlock - startingBlock) / (highestBlock - startingBlock)) * 100;
-
-    return (
-      <div className="pie-container">
-        <div
-          id="node-info__light"
-          className={this.state.lightClasses}
-          style={{
-            backgroundColor:
-              diff > 60 ? 'red' : active === 'remote' ? 'orange' : dotColor
-          }}
-        />
-        {active === 'remote' &&
-          currentBlock !== 0 && (
-            <PieChart
-              startAngle={-90}
-              style={{
-                position: 'absolute',
-                top: 22,
-                left: 0,
-                zIndex: 2,
-                height: 16
-              }}
-              data={[
-                { value: progress || 0, key: 1, color: dotColor },
-                { value: 100 - (progress || 1), key: 2, color: 'orange' }
-              ]}
-            />
-          )}
-      </div>
-    );
-  }
-
   render() {
-    const { network } = this.props;
+    const { active, network, remote, local } = this.props;
 
     let mainClass = network == 'main' ? 'node-mainnet' : 'node-testnet';
     if (this.state.sticky) mainClass += ' sticky';
@@ -310,7 +243,12 @@ class NodeInfo extends Component {
         onMouseEnter={() => this.setState({ showSubmenu: true })}
         onMouseLeave={() => this.setState({ showSubmenu: this.state.sticky })}
       >
-        {this.renderStatusLight()}
+        <StatusLight
+          active={active}
+          network={network}
+          remote={remote}
+          local={local}
+        />
 
         {this.state.showSubmenu && (
           <section className="node-info__submenu-container">


### PR DESCRIPTION
#### What does it do?
- Fixes bug where remote node was active and up to date, but status light was red, because infura wasn't connected.
- Fixes bug where new block animation was green when status light was blue.
- Adds NodeInfo dir and refactors out `StatusLight` component.
#### Relevant screenshots?
Before:
![screen shot 2018-10-11 at 6 02 15 pm](https://user-images.githubusercontent.com/3621728/46871401-8dd11300-cdee-11e8-94d4-6e159bf5e6df.png)