### PR TITLE
Shares time logic

### DIFF
--- a/interface/components/NodeInfo/index.js
+++ b/interface/components/NodeInfo/index.js
@@ -72,19 +72,7 @@ class NodeInfo extends Component {
           <div className="block-number row-icon">
             <i className="icon icon-layers" /> {formattedBlockNumber}
           </div>
-          <div
-            className={
-              diff > 60 ? 'block-diff row-icon red' : 'block-diff row-icon'
-            }
-          >
-            {
-              // TODO: make this i8n compatible
-            }
-            <i className="icon icon-clock" />
-            {diff < 120
-              ? diff + ' seconds'
-              : Math.floor(diff / 60) + ' minutes'}
-          </div>
+          {this.renderTimeSince(diff)}
         </div>
       );
     }
@@ -147,6 +135,23 @@ class NodeInfo extends Component {
     );
   }
 
+  renderTimeSince(diff) {
+    return (
+      <div
+        title={i18n.t('mist.nodeInfo.timeSinceBlock')}
+        className={
+          diff > 60 ? 'block-diff row-icon red' : 'block-diff row-icon'
+        }
+      >
+        {
+          // TODO: make this i8n compatible
+        }
+        <i className="icon icon-clock" />
+        {diff < 120 ? diff + ' seconds' : Math.floor(diff / 60) + ' minutes'}
+      </div>
+    );
+  }
+
   localStatsSynced() {
     const { blockNumber, timestamp, syncMode } = this.props.local;
     const formattedBlockNumber = numeral(blockNumber).format('0,0');
@@ -168,12 +173,7 @@ class NodeInfo extends Component {
             {` ${this.props.local.peerCount} ${i18n.t('mist.nodeInfo.peers')}`}
           </div>
         )}
-        <div
-          className="block-diff row-icon"
-          title={i18n.t('mist.nodeInfo.timeSinceBlock')}
-        >
-          <i className="icon icon-clock" /> {diff} seconds
-        </div>
+        {this.renderTimeSince(diff)}
       </div>
     );
   }


### PR DESCRIPTION
#### What does it do?
Shares time logic between remote and local displays, fixing a couple 'time since' bugs. 
   
#### Relevant screenshots?
Before:
- should show red text when >60 secs, and
- should display # of minutes when >120 secs
<img width="305" alt="screen shot 2018-10-16 at 11 07 08 am" src="https://user-images.githubusercontent.com/3621728/47034754-73bc6b00-d135-11e8-8341-bba18844d2ab.png">

After:
<img width="312" alt="screen shot 2018-10-16 at 11 14 03 am" src="https://user-images.githubusercontent.com/3621728/47034764-7b7c0f80-d135-11e8-9a4b-8838ed50c21a.png">
