### PR TITLE
Fixes submodule config for build pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "dapp-styles"]
-    path = interface/public/dapp-styles
-    url = git://github.com/ethereum/dapp-styles.git
+  path = interface/public/dapp-styles
+  url = git://github.com/ethereum/dapp-styles.git
 [submodule "meteor-dapp-wallet"]
 	path = meteor-dapp-wallet
-	url = https://github.com/ethereum/meteor-dapp-wallet.git
+  url = https://github.com/ethereum/meteor-dapp-wallet.git
+[submodule "wallet"]
+ 	path = wallet
+ 	url = git@github.com:ethereum/meteor-dapp-wallet.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "meteor-dapp-wallet"]
 	path = meteor-dapp-wallet
   url = https://github.com/ethereum/meteor-dapp-wallet.git
-[submodule "wallet"]
- 	path = wallet
- 	url = git@github.com:ethereum/meteor-dapp-wallet.git


### PR DESCRIPTION
#### What does it do?
This PR properly removes a former `wallet` submodule used in the build pipeline. As removing an entry from `.gitmodules` did not work, I used `git rm` to straighten internal git references.

#### How to test it?
Observe if the CIs will go past `git submodule update --init` phase.